### PR TITLE
Add multiple CardFolder support for Model and Storage components

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -3,6 +3,7 @@ package seedu.address;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
@@ -79,23 +80,23 @@ public class MainApp extends Application {
      * or an empty card folder will be used instead if errors occur when reading {@code storage}'s card folder.
      */
     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
-        Optional<ReadOnlyCardFolder> cardFolderOptional;
-        ReadOnlyCardFolder initialData;
+        List<ReadOnlyCardFolder> initialCardFolders;
+        // TODO: For exception handling, allow non-corrupted folders to be displayed
         try {
-            cardFolderOptional = storage.readCardFolder();
-            if (!cardFolderOptional.isPresent()) {
+            initialCardFolders = storage.readCardFolders();
+            if (initialCardFolders.isEmpty()) {
                 logger.info("Data file not found. Will be starting with a sample CardFolder");
+                initialCardFolders.add(SampleDataUtil.getSampleCardFolder());
             }
-            initialData = cardFolderOptional.orElseGet(SampleDataUtil::getSampleCardFolder);
         } catch (DataConversionException e) {
             logger.warning("Data file not in the correct format. Will be starting with an empty CardFolder");
-            initialData = new CardFolder();
+            initialCardFolders = Collections.singletonList(new CardFolder());
         } catch (IOException e) {
             logger.warning("Problem while reading from the file. Will be starting with an empty CardFolder");
-            initialData = new CardFolder();
+            initialCardFolders = Collections.singletonList(new CardFolder());
         }
 
-        return new ModelManager(initialData, userPrefs);
+        return new ModelManager(initialCardFolders, userPrefs);
     }
 
     private void initLogging(Config config) {

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -2,6 +2,8 @@ package seedu.address;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -56,8 +58,11 @@ public class MainApp extends Application {
 
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
-        CardFolderStorage cardFolderStorage = new JsonCardFolderStorage(userPrefs.getCardFolderFilePath());
-        storage = new StorageManager(cardFolderStorage, userPrefsStorage);
+        List<CardFolderStorage> cardFolderStorageList = new ArrayList<>();
+        // TODO: Iterate over all files in directory
+        Path cardFolderFilesPath = userPrefs.getcardFolderFilesPath();
+        cardFolderStorageList.add(new JsonCardFolderStorage(cardFolderFilesPath));
+        storage = new StorageManager(cardFolderStorageList, userPrefsStorage);
 
         initLogging(config);
 

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -27,7 +27,7 @@ public interface Logic {
     /**
      * Returns the CardFolder.
      *
-     * @see seedu.address.model.Model#getCardFolder()
+     * @see seedu.address.model.Model#getActiveCardFolder()
      */
     ReadOnlyCardFolder getCardFolder();
 

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -43,7 +43,7 @@ public interface Logic {
     /**
      * Returns the user prefs' card folder file path.
      */
-    Path getCardFolderFilePath();
+    Path getcardFolderFilesPath();
 
     /**
      * Returns the user prefs' GUI settings.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -38,7 +38,7 @@ public class LogicManager implements Logic {
         cardFolderParser = new CardFolderParser();
 
         // Set cardFolderModified to true whenever the models' card folder is modified.
-        model.getCardFolder().addListener(observable -> cardFolderModified = true);
+        model.getActiveCardFolder().addListener(observable -> cardFolderModified = true);
     }
 
     @Override
@@ -57,7 +57,7 @@ public class LogicManager implements Logic {
         if (cardFolderModified) {
             logger.info("card folder modified, saving to file.");
             try {
-                storage.saveCardFolder(model.getCardFolder());
+                storage.saveCardFolder(model.getActiveCardFolder());
             } catch (IOException ioe) {
                 throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
             }
@@ -68,12 +68,12 @@ public class LogicManager implements Logic {
 
     @Override
     public ReadOnlyCardFolder getCardFolder() {
-        return model.getCardFolder();
+        return model.getActiveCardFolder();
     }
 
     @Override
     public ObservableList<Card> getFilteredCardList() {
-        return model.getFilteredCardList();
+        return model.getFilteredCards();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -82,8 +82,8 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public Path getCardFolderFilePath() {
-        return model.getCardFolderFilePath();
+    public Path getcardFolderFilesPath() {
+        return model.getcardFolderFilesPath();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -34,7 +34,7 @@ public class DeleteCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
-        List<Card> lastShownList = model.getFilteredCardList();
+        List<Card> lastShownList = model.getFilteredCards();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -69,7 +69,7 @@ public class EditCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
-        List<Card> lastShownList = model.getFilteredCardList();
+        List<Card> lastShownList = model.getFilteredCards();
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
@@ -83,7 +83,7 @@ public class EditCommand extends Command {
         }
 
         model.setCard(cardToEdit, editedCard);
-        model.updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
+        model.updateFilteredCard(PREDICATE_SHOW_ALL_CARDS);
         model.commitCardFolder();
         return new CommandResult(String.format(MESSAGE_EDIT_CARD_SUCCESS, editedCard));
     }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -29,9 +29,9 @@ public class FindCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        model.updateFilteredCardList(predicate);
+        model.updateFilteredCard(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_CARDS_LISTED_OVERVIEW, model.getFilteredCardList().size()));
+                String.format(Messages.MESSAGE_CARDS_LISTED_OVERVIEW, model.getFilteredCards().size()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -19,7 +19,7 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        model.updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
+        model.updateFilteredCard(PREDICATE_SHOW_ALL_CARDS);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -25,7 +25,7 @@ public class RedoCommand extends Command {
         }
 
         model.redoCardFolder();
-        model.updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
+        model.updateFilteredCard(PREDICATE_SHOW_ALL_CARDS);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectCommand.java
@@ -35,7 +35,7 @@ public class SelectCommand extends Command {
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
 
-        List<Card> filteredCardList = model.getFilteredCardList();
+        List<Card> filteredCardList = model.getFilteredCards();
 
         if (targetIndex.getZeroBased() >= filteredCardList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -25,7 +25,7 @@ public class UndoCommand extends Command {
         }
 
         model.undoCardFolder();
-        model.updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
+        model.updateFilteredCard(PREDICATE_SHOW_ALL_CARDS);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/model/CardFolder.java
+++ b/src/main/java/seedu/address/model/CardFolder.java
@@ -59,6 +59,7 @@ public class CardFolder implements ReadOnlyCardFolder {
         requireNonNull(newData);
 
         setCards(newData.getCardList());
+        setFolderName(newData.getFolderName());
     }
 
     //// card-level operations
@@ -136,6 +137,7 @@ public class CardFolder implements ReadOnlyCardFolder {
      */
     public void setFolderName(String folderName) {
         this.folderName = folderName;
+        indicateModified();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/CardFolder.java
+++ b/src/main/java/seedu/address/model/CardFolder.java
@@ -133,10 +133,10 @@ public class CardFolder implements ReadOnlyCardFolder {
     }
 
     /**
-     * Javadoc comment
+     * Sets the name of the {@code CardFolder} and overwrites the previous name.
      */
-    public void setFolderName(String folderName) {
-        this.folderName = folderName;
+    public void setFolderName(String newFolderName) {
+        this.folderName = newFolderName;
         indicateModified();
     }
 
@@ -145,6 +145,7 @@ public class CardFolder implements ReadOnlyCardFolder {
         return folderName;
     }
 
+    // TODO: Check for folder equivalence with folderName instead
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object

--- a/src/main/java/seedu/address/model/CardFolder.java
+++ b/src/main/java/seedu/address/model/CardFolder.java
@@ -17,6 +17,7 @@ import seedu.address.model.card.UniqueCardList;
 public class CardFolder implements ReadOnlyCardFolder {
 
     private final UniqueCardList cards;
+    private String folderName;
     private final InvalidationListenerManager invalidationListenerManager = new InvalidationListenerManager();
 
     /*
@@ -128,6 +129,18 @@ public class CardFolder implements ReadOnlyCardFolder {
     @Override
     public ObservableList<Card> getCardList() {
         return cards.asUnmodifiableObservableList();
+    }
+
+    /**
+     * Javadoc comment
+     */
+    public void setFolderName(String folderName) {
+        this.folderName = folderName;
+    }
+
+    @Override
+    public String getFolderName() {
+        return folderName;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/DuplicateCardFolderException.java
+++ b/src/main/java/seedu/address/model/DuplicateCardFolderException.java
@@ -1,0 +1,11 @@
+package seedu.address.model;
+
+/**
+ * Signals that the operation will result in duplicate Cards (Cards are considered duplicates if they have the same
+ * identity).
+ */
+public class DuplicateCardFolderException extends RuntimeException {
+    public DuplicateCardFolderException() {
+        super("Operation would result in duplicate card folders");
+    }
+}

--- a/src/main/java/seedu/address/model/FolderDirectory.java
+++ b/src/main/java/seedu/address/model/FolderDirectory.java
@@ -1,8 +1,0 @@
-package seedu.address.model;
-
-/**
- * Javadoc comment
- */
-public class FolderDirectory {
-
-}

--- a/src/main/java/seedu/address/model/FolderDirectory.java
+++ b/src/main/java/seedu/address/model/FolderDirectory.java
@@ -1,0 +1,8 @@
+package seedu.address.model;
+
+/**
+ * Javadoc comment
+ */
+public class FolderDirectory {
+
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.beans.property.ReadOnlyProperty;
@@ -50,8 +51,11 @@ public interface Model {
      */
     void setCardFolder(ReadOnlyCardFolder cardFolder);
 
-    /** Returns the CardFolder */
-    ReadOnlyCardFolder getCardFolder();
+    /** Returns the active CardFolder */
+    ReadOnlyCardFolder getActiveCardFolder();
+
+    /** Returns all CardFolders */
+    List<ReadOnlyCardFolder> getCardFolders();
 
     /**
      * Returns true if a card with the same identity as {@code card} exists in the card folder.
@@ -78,13 +82,13 @@ public interface Model {
     void setCard(Card target, Card editedCard);
 
     /** Returns an unmodifiable view of the filtered card list */
-    ObservableList<Card> getFilteredCardList();
+    ObservableList<Card> getFilteredCards();
 
     /**
      * Updates the filter of the filtered card list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
-    void updateFilteredCardList(Predicate<Card> predicate);
+    void updateFilteredCard(Predicate<Card> predicate);
 
     /**
      * Returns true if the model has previous card folder states to restore.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -38,12 +38,12 @@ public interface Model {
     /**
      * Returns the user prefs' card folder file path.
      */
-    Path getCardFolderFilePath();
+    Path getcardFolderFilesPath();
 
     /**
      * Sets the user prefs' card folder file path.
      */
-    void setCardFolderFilePath(Path cardFolderFilePath);
+    void setcardFolderFilesPath(Path cardFolderFilesPath);
 
     /**
      * Replaces card folder data with the data in {@code cardFolder}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -73,14 +73,14 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public Path getCardFolderFilePath() {
-        return userPrefs.getCardFolderFilePath();
+    public Path getcardFolderFilesPath() {
+        return userPrefs.getcardFolderFilesPath();
     }
 
     @Override
-    public void setCardFolderFilePath(Path cardFolderFilePath) {
-        requireNonNull(cardFolderFilePath);
-        userPrefs.setCardFolderFilePath(cardFolderFilePath);
+    public void setcardFolderFilesPath(Path cardFolderFilesPath) {
+        requireNonNull(cardFolderFilesPath);
+        userPrefs.setcardFolderFilesPath(cardFolderFilesPath);
     }
 
     //=========== CardFolder ================================================================================

--- a/src/main/java/seedu/address/model/ReadOnlyCardFolder.java
+++ b/src/main/java/seedu/address/model/ReadOnlyCardFolder.java
@@ -16,7 +16,7 @@ public interface ReadOnlyCardFolder extends Observable {
     ObservableList<Card> getCardList();
 
     /**
-     * Javadoc comment
+     * Returns the name of the folder.
      */
     String getFolderName();
 

--- a/src/main/java/seedu/address/model/ReadOnlyCardFolder.java
+++ b/src/main/java/seedu/address/model/ReadOnlyCardFolder.java
@@ -15,4 +15,9 @@ public interface ReadOnlyCardFolder extends Observable {
      */
     ObservableList<Card> getCardList();
 
+    /**
+     * Javadoc comment
+     */
+    String getFolderName();
+
 }

--- a/src/main/java/seedu/address/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/seedu/address/model/ReadOnlyUserPrefs.java
@@ -11,6 +11,6 @@ public interface ReadOnlyUserPrefs {
 
     GuiSettings getGuiSettings();
 
-    Path getCardFolderFilePath();
+    Path getcardFolderFilesPath();
 
 }

--- a/src/main/java/seedu/address/model/UniqueCardFolderList.java
+++ b/src/main/java/seedu/address/model/UniqueCardFolderList.java
@@ -1,0 +1,38 @@
+package seedu.address.model;
+
+import static java.util.Objects.requireNonNull;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+/**
+ * Javadoc comment
+ */
+public class UniqueCardFolderList {
+
+    private final ObservableList<CardFolder> internalList = FXCollections.observableArrayList();
+    private final ObservableList<CardFolder> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Javadoc comment
+     * @param toCheck
+     * @return
+     */
+    public boolean contains(CardFolder toCheck) {
+        requireNonNull(toCheck);
+        // TODO: Currently checking based on folder cards, should it be based on folder name?
+        return internalList.stream().anyMatch(toCheck::equals);
+    }
+
+    /**
+     * Javadoc comment
+     * @param toAdd
+     */
+    public void add(CardFolder toAdd) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw new DuplicateCardFolderException();
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/UniqueCardFolderList.java
+++ b/src/main/java/seedu/address/model/UniqueCardFolderList.java
@@ -6,7 +6,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 /**
- * Javadoc comment
+ * A list of folders that enforces uniqueness between its elements. To be completed.
  */
 public class UniqueCardFolderList {
 
@@ -15,9 +15,7 @@ public class UniqueCardFolderList {
             FXCollections.unmodifiableObservableList(internalList);
 
     /**
-     * Javadoc comment
-     * @param toCheck
-     * @return
+     * Returns true if the list contains an equivalent folder as the given argument.
      */
     public boolean contains(CardFolder toCheck) {
         requireNonNull(toCheck);
@@ -26,8 +24,8 @@ public class UniqueCardFolderList {
     }
 
     /**
-     * Javadoc comment
-     * @param toAdd
+     * Adds a folder to the list.
+     * The folder must not already exist in the list.
      */
     public void add(CardFolder toAdd) {
         requireNonNull(toAdd);

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 import java.util.Objects;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.storage.StorageManager;
 
 /**
  * Represents User's preferences.
@@ -14,7 +15,7 @@ import seedu.address.commons.core.GuiSettings;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
-    private Path cardFolderFilePath = Paths.get("data" , "cardfolder.json");
+    private Path cardFolderFilesPath = Paths.get("data" , StorageManager.DEFAULT_FOLDER_NAME);
 
     /**
      * Creates a {@code UserPrefs} with default values.
@@ -35,7 +36,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     public void resetData(ReadOnlyUserPrefs newUserPrefs) {
         requireNonNull(newUserPrefs);
         setGuiSettings(newUserPrefs.getGuiSettings());
-        setCardFolderFilePath(newUserPrefs.getCardFolderFilePath());
+        setcardFolderFilesPath(newUserPrefs.getcardFolderFilesPath());
     }
 
     public GuiSettings getGuiSettings() {
@@ -47,13 +48,13 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         this.guiSettings = guiSettings;
     }
 
-    public Path getCardFolderFilePath() {
-        return cardFolderFilePath;
+    public Path getcardFolderFilesPath() {
+        return cardFolderFilesPath;
     }
 
-    public void setCardFolderFilePath(Path cardFolderFilePath) {
-        requireNonNull(cardFolderFilePath);
-        this.cardFolderFilePath = cardFolderFilePath;
+    public void setcardFolderFilesPath(Path cardFolderFilesPath) {
+        requireNonNull(cardFolderFilesPath);
+        this.cardFolderFilesPath = cardFolderFilesPath;
     }
 
     @Override
@@ -68,19 +69,19 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         UserPrefs o = (UserPrefs) other;
 
         return guiSettings.equals(o.guiSettings)
-                && cardFolderFilePath.equals(o.cardFolderFilePath);
+                && cardFolderFilesPath.equals(o.cardFolderFilesPath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(guiSettings, cardFolderFilePath);
+        return Objects.hash(guiSettings, cardFolderFilesPath);
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("Gui Settings : " + guiSettings);
-        sb.append("\nLocal data file location : " + cardFolderFilePath);
+        sb.append("\nLocal data file location : " + cardFolderFilesPath);
         return sb.toString();
     }
 

--- a/src/main/java/seedu/address/storage/CardFolderStorage.java
+++ b/src/main/java/seedu/address/storage/CardFolderStorage.java
@@ -16,7 +16,7 @@ public interface CardFolderStorage {
     /**
      * Returns the file path of the data file.
      */
-    Path getCardFolderFilePath();
+    Path getcardFolderFilesPath();
 
     /**
      * Returns CardFolder data as a {@link ReadOnlyCardFolder}.
@@ -27,9 +27,15 @@ public interface CardFolderStorage {
     Optional<ReadOnlyCardFolder> readCardFolder() throws DataConversionException, IOException;
 
     /**
-     * @see #getCardFolderFilePath()
+     * @see #getcardFolderFilesPath()
      */
     Optional<ReadOnlyCardFolder> readCardFolder(Path filePath) throws DataConversionException, IOException;
+
+    /**
+     * Returns a the name of the card folder, which uniquely identifies it.
+     *  Returns {@code Optional.empty()} if storage file is not found.
+     */
+    Optional<String> getCardFolderName() throws DataConversionException, IOException;
 
     /**
      * Saves the given {@link ReadOnlyCardFolder} to the storage.

--- a/src/main/java/seedu/address/storage/JsonCardFolderStorage.java
+++ b/src/main/java/seedu/address/storage/JsonCardFolderStorage.java
@@ -27,7 +27,7 @@ public class JsonCardFolderStorage implements CardFolderStorage {
         this.filePath = filePath;
     }
 
-    public Path getCardFolderFilePath() {
+    public Path getcardFolderFilesPath() {
         return filePath;
     }
 
@@ -57,6 +57,15 @@ public class JsonCardFolderStorage implements CardFolderStorage {
             logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
             throw new DataConversionException(ive);
         }
+    }
+
+    @Override
+    public Optional<String> getCardFolderName() throws DataConversionException, IOException {
+        Optional<ReadOnlyCardFolder> readOnlyCardFolder = readCardFolder();
+        if (!readOnlyCardFolder.isPresent()) {
+            return Optional.empty();
+        }
+        return Optional.of(StorageManager.DEFAULT_FOLDER_NAME);
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonSerializableCardFolder.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableCardFolder.java
@@ -21,13 +21,16 @@ class JsonSerializableCardFolder {
 
     public static final String MESSAGE_DUPLICATE_CARD = "Cards list contains duplicate card(s).";
 
+    private final String folderName;
     private final List<JsonAdaptedCard> cards = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableCardFolder} with the given cards.
      */
     @JsonCreator
-    public JsonSerializableCardFolder(@JsonProperty("cards") List<JsonAdaptedCard> cards) {
+    public JsonSerializableCardFolder(@JsonProperty("folderName") String folderName,
+                                      @JsonProperty("cards") List<JsonAdaptedCard> cards) {
+        this.folderName = folderName;
         this.cards.addAll(cards);
     }
 
@@ -38,6 +41,7 @@ class JsonSerializableCardFolder {
      */
     public JsonSerializableCardFolder(ReadOnlyCardFolder source) {
         cards.addAll(source.getCardList().stream().map(JsonAdaptedCard::new).collect(Collectors.toList()));
+        folderName = source.getFolderName();
     }
 
     /**
@@ -54,6 +58,7 @@ class JsonSerializableCardFolder {
             }
             cardFolder.addCard(card);
         }
+        cardFolder.setFolderName(folderName);
         return cardFolder;
     }
 

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 
 import seedu.address.commons.exceptions.DataConversionException;
@@ -16,7 +17,7 @@ public interface Storage {
     Optional<UserPrefs> readUserPrefs() throws DataConversionException, IOException;
     void saveUserPrefs(ReadOnlyUserPrefs userPrefs) throws IOException;
     Path getcardFolderFilesPath();
-    Optional<ReadOnlyCardFolder> readCardFolder() throws DataConversionException, IOException;
+    List<ReadOnlyCardFolder> readCardFolders() throws DataConversionException, IOException;
     void saveCardFolder(ReadOnlyCardFolder cardFolder) throws IOException;
 
 }

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -12,21 +12,11 @@ import seedu.address.model.UserPrefs;
 /**
  * API of the Storage component
  */
-public interface Storage extends CardFolderStorage, UserPrefsStorage {
-
-    @Override
+public interface Storage {
     Optional<UserPrefs> readUserPrefs() throws DataConversionException, IOException;
-
-    @Override
     void saveUserPrefs(ReadOnlyUserPrefs userPrefs) throws IOException;
-
-    @Override
-    Path getCardFolderFilePath();
-
-    @Override
+    Path getcardFolderFilesPath();
     Optional<ReadOnlyCardFolder> readCardFolder() throws DataConversionException, IOException;
-
-    @Override
     void saveCardFolder(ReadOnlyCardFolder cardFolder) throws IOException;
 
 }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -57,12 +57,18 @@ public class StorageManager implements Storage {
     }
 
     @Override
-    public Optional<ReadOnlyCardFolder> readCardFolder() throws DataConversionException, IOException {
-        return readCardFolder(cardFolderStorageList.get(0).getcardFolderFilesPath());
+    public List<ReadOnlyCardFolder> readCardFolders() throws DataConversionException, IOException {
+        List<ReadOnlyCardFolder> cardFolders = new ArrayList<>();
+        for (CardFolderStorage cardFolderStorage : cardFolderStorageList) {
+            Optional<ReadOnlyCardFolder> cardFolder = readCardFolder(cardFolderStorage.getcardFolderFilesPath());
+            cardFolder.ifPresent(cardFolders::add);
+        }
+        return cardFolders;
     }
 
     /**
-     * Javadoc comment
+     * Reads a {@code ReadOnlyCardFolder} at the specified filepath.
+     * @return {@code Optional.empty} if the file is not found.
      */
     public Optional<ReadOnlyCardFolder> readCardFolder(Path filePath) throws DataConversionException, IOException {
         logger.fine("Attempting to read data from file: " + filePath);
@@ -76,7 +82,7 @@ public class StorageManager implements Storage {
     }
 
     /**
-     * Javadoc comment
+     * Saves the CardFolder to the specified filePath
      */
     public void saveCardFolder(ReadOnlyCardFolder cardFolder, Path filePath) throws IOException {
         logger.fine("Attempting to write to data file: " + filePath);

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -2,6 +2,8 @@ package seedu.address.storage;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -16,20 +18,22 @@ import seedu.address.model.UserPrefs;
  */
 public class StorageManager implements Storage {
 
+    // Temporary constant
+    public static final String DEFAULT_FOLDER_NAME = "cardfolder";
     private static final Logger logger = LogsCenter.getLogger(StorageManager.class);
-    private CardFolderStorage cardFolderStorage;
+    private List<CardFolderStorage> cardFolderStorageList;
     private UserPrefsStorage userPrefsStorage;
 
 
-    public StorageManager(CardFolderStorage cardFolderStorage, UserPrefsStorage userPrefsStorage) {
+    public StorageManager(List<CardFolderStorage> cardFolderStorageList, UserPrefsStorage userPrefsStorage) {
         super();
-        this.cardFolderStorage = cardFolderStorage;
+        this.cardFolderStorageList = new ArrayList<>(cardFolderStorageList);
         this.userPrefsStorage = userPrefsStorage;
     }
 
     // ================ UserPrefs methods ==============================
 
-    @Override
+
     public Path getUserPrefsFilePath() {
         return userPrefsStorage.getUserPrefsFilePath();
     }
@@ -48,30 +52,35 @@ public class StorageManager implements Storage {
     // ================ CardFolder methods ==============================
 
     @Override
-    public Path getCardFolderFilePath() {
-        return cardFolderStorage.getCardFolderFilePath();
+    public Path getcardFolderFilesPath() {
+        return cardFolderStorageList.get(0).getcardFolderFilesPath();
     }
 
     @Override
     public Optional<ReadOnlyCardFolder> readCardFolder() throws DataConversionException, IOException {
-        return readCardFolder(cardFolderStorage.getCardFolderFilePath());
+        return readCardFolder(cardFolderStorageList.get(0).getcardFolderFilesPath());
     }
 
-    @Override
+    /**
+     * Javadoc comment
+     */
     public Optional<ReadOnlyCardFolder> readCardFolder(Path filePath) throws DataConversionException, IOException {
         logger.fine("Attempting to read data from file: " + filePath);
-        return cardFolderStorage.readCardFolder(filePath);
+        return cardFolderStorageList.get(0).readCardFolder(filePath);
     }
+
 
     @Override
     public void saveCardFolder(ReadOnlyCardFolder cardFolder) throws IOException {
-        saveCardFolder(cardFolder, cardFolderStorage.getCardFolderFilePath());
+        saveCardFolder(cardFolder, cardFolderStorageList.get(0).getcardFolderFilesPath());
     }
 
-    @Override
+    /**
+     * Javadoc comment
+     */
     public void saveCardFolder(ReadOnlyCardFolder cardFolder, Path filePath) throws IOException {
         logger.fine("Attempting to write to data file: " + filePath);
-        cardFolderStorage.saveCardFolder(cardFolder, filePath);
+        cardFolderStorageList.get(0).saveCardFolder(cardFolder, filePath);
     }
 
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -121,7 +121,7 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
-        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getCardFolderFilePath(), logic.getCardFolder());
+        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getcardFolderFilesPath(), logic.getCardFolder());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
         CommandBox commandBox = new CommandBox(this::executeCommand, logic.getHistory());

--- a/src/test/data/JsonCardFolderStorageTest/invalidAndValidCardCardFolder.json
+++ b/src/test/data/JsonCardFolderStorageTest/invalidAndValidCardCardFolder.json
@@ -1,4 +1,5 @@
 {
+  "folderName": "Invalid and Valid",
   "cards": [ {
     "question": "Valid Card",
     "answer": "9482424",

--- a/src/test/data/JsonCardFolderStorageTest/invalidCardCardFolder.json
+++ b/src/test/data/JsonCardFolderStorageTest/invalidCardCardFolder.json
@@ -1,4 +1,5 @@
 {
+  "folderName" : "Invalid question",
   "cards": [ {
     "question": "Card with invalid question field: Ha!ns Mu@ster",
     "answer": "9482424",

--- a/src/test/data/JsonSerializableCardFolderTest/duplicateThumbnailCardFolder.json
+++ b/src/test/data/JsonSerializableCardFolderTest/duplicateThumbnailCardFolder.json
@@ -1,4 +1,5 @@
 {
+  "folderName": "Duplicate Thumbnail",
   "cards": [ {
     "question": "Alice Pauline",
     "answer": "94351253",

--- a/src/test/data/JsonSerializableCardFolderTest/invalidCardCardFolder.json
+++ b/src/test/data/JsonSerializableCardFolderTest/invalidCardCardFolder.json
@@ -1,4 +1,5 @@
 {
+  "folderName": "Invalid Card",
   "cards": [ {
     "question": "Hans Muster",
     "answer": "9482424",

--- a/src/test/data/JsonSerializableCardFolderTest/typicalCardsCardFolder.json
+++ b/src/test/data/JsonSerializableCardFolderTest/typicalCardsCardFolder.json
@@ -1,5 +1,6 @@
 {
   "_comment": "CardFolder save file which contains the same Card values as in TypicalCards#getTypicalCardFolder()",
+  "folderName": "Typical Cards",
   "cards" : [ {
     "question" : "Alice Pauline",
     "answer" : "94351253",

--- a/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
@@ -9,5 +9,5 @@
       "z" : 99
     }
   },
-  "cardFolderFilePath" : "cardfolder.json"
+  "cardFolderFilesPath" : "cardfolder.json"
 }

--- a/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
@@ -7,5 +7,5 @@
       "y" : 100
     }
   },
-  "cardFolderFilePath" : "cardfolder.json"
+  "cardFolderFilesPath" : "cardfolder.json"
 }

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -2,6 +2,7 @@ package seedu.address;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.function.Supplier;
 
 import javafx.stage.Screen;
@@ -73,7 +74,8 @@ public class TestApp extends MainApp {
      */
     public CardFolder readStorageCardFolder() {
         try {
-            return new CardFolder(storage.readCardFolder().get());
+            // TODO: Address hardcoding in the following line
+            return new CardFolder(storage.readCardFolders().get(0));
         } catch (DataConversionException dce) {
             throw new AssertionError("Data is not in the CardFolder format.", dce);
         } catch (IOException ioe) {
@@ -92,8 +94,9 @@ public class TestApp extends MainApp {
      * Returns a defensive copy of the model.
      */
     public Model getModel() {
-        Model copy = new ModelManager((model.getCardFolder()), new UserPrefs());
-        ModelHelper.setFilteredList(copy, model.getFilteredCardList());
+        Model copy = new ModelManager(Collections.singletonList(model.getActiveCardFolder()),
+                new UserPrefs());
+        ModelHelper.setFilteredList(copy, model.getFilteredCards());
         return copy;
     }
 

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -64,7 +64,7 @@ public class TestApp extends MainApp {
         double x = Screen.getPrimary().getVisualBounds().getMinX();
         double y = Screen.getPrimary().getVisualBounds().getMinY();
         userPrefs.setGuiSettings(new GuiSettings(600.0, 600.0, (int) x, (int) y));
-        userPrefs.setCardFolderFilePath(saveFileLocation);
+        userPrefs.setcardFolderFilesPath(saveFileLocation);
         return userPrefs;
     }
 
@@ -85,7 +85,7 @@ public class TestApp extends MainApp {
      * Returns the file path of the storage file.
      */
     public Path getStorageSaveLocation() {
-        return storage.getCardFolderFilePath();
+        return storage.getcardFolderFilesPath();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -11,6 +11,8 @@ import static seedu.address.testutil.TypicalCards.AMY;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -29,6 +31,7 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyCardFolder;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.card.Card;
+import seedu.address.storage.CardFolderStorage;
 import seedu.address.storage.JsonCardFolderStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.StorageManager;
@@ -50,8 +53,11 @@ public class LogicManagerTest {
     @Before
     public void setUp() throws Exception {
         JsonCardFolderStorage cardFolderStorage = new JsonCardFolderStorage(temporaryFolder.newFile().toPath());
+        List<CardFolderStorage> cardFolderStorageList = new ArrayList<>();
+        // TODO: Iterate over all files in directory
+        cardFolderStorageList.add(cardFolderStorage);
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.newFile().toPath());
-        StorageManager storage = new StorageManager(cardFolderStorage, userPrefsStorage);
+        StorageManager storage = new StorageManager(cardFolderStorageList, userPrefsStorage);
         logic = new LogicManager(model, storage);
     }
 
@@ -81,8 +87,11 @@ public class LogicManagerTest {
         // Setup LogicManager with JsonCardFolderIoExceptionThrowingStub
         JsonCardFolderStorage cardFolderStorage =
                 new JsonCardFolderIoExceptionThrowingStub(temporaryFolder.newFile().toPath());
+        List<CardFolderStorage> cardFolderStorageList = new ArrayList<>();
+        // TODO: Iterate over all files in directory
+        cardFolderStorageList.add(cardFolderStorage);
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.newFile().toPath());
-        StorageManager storage = new StorageManager(cardFolderStorage, userPrefsStorage);
+        StorageManager storage = new StorageManager(cardFolderStorageList, userPrefsStorage);
         logic = new LogicManager(model, storage);
 
         // Execute add command

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -12,6 +12,7 @@ import static seedu.address.testutil.TypicalCards.AMY;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
@@ -142,7 +143,8 @@ public class LogicManagerTest {
      * @see #assertCommandBehavior(Class, String, String, Model)
      */
     private void assertCommandFailure(String inputCommand, Class<?> expectedException, String expectedMessage) {
-        Model expectedModel = new ModelManager(model.getCardFolder(), new UserPrefs());
+        Model expectedModel = new ModelManager(Collections.singletonList(model.getActiveCardFolder()),
+                new UserPrefs());
         assertCommandBehavior(expectedException, inputCommand, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalCards.getTypicalCardFolder;
+import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -24,14 +24,14 @@ public class AddCommandIntegrationTest {
 
     @Before
     public void setUp() {
-        model = new ModelManager(getTypicalCardFolder(), new UserPrefs());
+        model = new ModelManager(getTypicalCardFolders(), new UserPrefs());
     }
 
     @Test
     public void execute_newCard_success() {
         Card validCard = new CardBuilder().build();
 
-        Model expectedModel = new ModelManager(model.getCardFolder(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getCardFolders(), new UserPrefs());
         expectedModel.addCard(validCard);
         expectedModel.commitCardFolder();
 
@@ -41,7 +41,7 @@ public class AddCommandIntegrationTest {
 
     @Test
     public void execute_duplicateCard_throwsCommandException() {
-        Card cardInList = model.getCardFolder().getCardList().get(0);
+        Card cardInList = model.getActiveCardFolder().getCardList().get(0);
         assertCommandFailure(new AddCommand(cardInList), model, commandHistory,
                 AddCommand.MESSAGE_DUPLICATE_CARD);
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.Rule;
@@ -134,7 +135,12 @@ public class AddCommandTest {
         }
 
         @Override
-        public ReadOnlyCardFolder getCardFolder() {
+        public ReadOnlyCardFolder getActiveCardFolder() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public List<ReadOnlyCardFolder> getCardFolders() {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -154,12 +160,12 @@ public class AddCommandTest {
         }
 
         @Override
-        public ObservableList<Card> getFilteredCardList() {
+        public ObservableList<Card> getFilteredCards() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void updateFilteredCardList(Predicate<Card> predicate) {
+        public void updateFilteredCard(Predicate<Card> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -246,7 +252,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public ReadOnlyCardFolder getCardFolder() {
+        public ReadOnlyCardFolder getActiveCardFolder() {
             return new CardFolder();
         }
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -114,12 +114,12 @@ public class AddCommandTest {
         }
 
         @Override
-        public Path getCardFolderFilePath() {
+        public Path getcardFolderFilesPath() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void setCardFolderFilePath(Path cardFolderFilePath) {
+        public void setcardFolderFilesPath(Path cardFolderFilesPath) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalCards.getTypicalCardFolder;
+import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
 
 import org.junit.Test;
 
@@ -26,8 +26,8 @@ public class ClearCommandTest {
 
     @Test
     public void execute_nonEmptyCardFolder_success() {
-        Model model = new ModelManager(getTypicalCardFolder(), new UserPrefs());
-        Model expectedModel = new ModelManager(getTypicalCardFolder(), new UserPrefs());
+        Model model = new ModelManager(getTypicalCardFolders(), new UserPrefs());
+        Model expectedModel = new ModelManager(getTypicalCardFolders(), new UserPrefs());
         expectedModel.setCardFolder(new CardFolder());
         expectedModel.commitCardFolder();
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -109,8 +109,8 @@ public class CommandTestUtil {
             String expectedMessage) {
         // we are unable to defensively copy the model for comparison later, so we can
         // only do so by copying its components.
-        CardFolder expectedCardFolder = new CardFolder(actualModel.getCardFolder());
-        List<Card> expectedFilteredList = new ArrayList<>(actualModel.getFilteredCardList());
+        CardFolder expectedCardFolder = new CardFolder(actualModel.getActiveCardFolder());
+        List<Card> expectedFilteredList = new ArrayList<>(actualModel.getFilteredCards());
         Card expectedSelectedCard = actualModel.getSelectedCard();
 
         CommandHistory expectedCommandHistory = new CommandHistory(actualCommandHistory);
@@ -120,8 +120,8 @@ public class CommandTestUtil {
             throw new AssertionError("The expected CommandException was not thrown.");
         } catch (CommandException e) {
             assertEquals(expectedMessage, e.getMessage());
-            assertEquals(expectedCardFolder, actualModel.getCardFolder());
-            assertEquals(expectedFilteredList, actualModel.getFilteredCardList());
+            assertEquals(expectedCardFolder, actualModel.getActiveCardFolder());
+            assertEquals(expectedFilteredList, actualModel.getFilteredCards());
             assertEquals(expectedSelectedCard, actualModel.getSelectedCard());
             assertEquals(expectedCommandHistory, actualCommandHistory);
         }
@@ -132,20 +132,20 @@ public class CommandTestUtil {
      * {@code model}'s card folder.
      */
     public static void showCardAtIndex(Model model, Index targetIndex) {
-        assertTrue(targetIndex.getZeroBased() < model.getFilteredCardList().size());
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredCards().size());
 
-        Card card = model.getFilteredCardList().get(targetIndex.getZeroBased());
+        Card card = model.getFilteredCards().get(targetIndex.getZeroBased());
         final String[] splitQuestion = card.getQuestion().fullQuestion.split("\\s+");
-        model.updateFilteredCardList(new QuestionContainsKeywordsPredicate(Arrays.asList(splitQuestion[0])));
+        model.updateFilteredCard(new QuestionContainsKeywordsPredicate(Arrays.asList(splitQuestion[0])));
 
-        assertEquals(1, model.getFilteredCardList().size());
+        assertEquals(1, model.getFilteredCards().size());
     }
 
     /**
      * Deletes the first card in {@code model}'s filtered list from {@code model}'s card folder.
      */
     public static void deleteFirstCard(Model model) {
-        Card firstCard = model.getFilteredCardList().get(0);
+        Card firstCard = model.getFilteredCards().get(0);
         model.deleteCard(firstCard);
         model.commitCardFolder();
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showCardAtIndex;
-import static seedu.address.testutil.TypicalCards.getTypicalCardFolder;
+import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CARD;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CARD;
 
@@ -26,17 +26,17 @@ import seedu.address.model.card.Card;
  */
 public class DeleteCommandTest {
 
-    private Model model = new ModelManager(getTypicalCardFolder(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalCardFolders(), new UserPrefs());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Card cardToDelete = model.getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased());
+        Card cardToDelete = model.getFilteredCards().get(INDEX_FIRST_CARD.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_CARD);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CARD_SUCCESS, cardToDelete);
 
-        ModelManager expectedModel = new ModelManager(model.getCardFolder(), new UserPrefs());
+        ModelManager expectedModel = new ModelManager(model.getCardFolders(), new UserPrefs());
         expectedModel.deleteCard(cardToDelete);
         expectedModel.commitCardFolder();
 
@@ -45,7 +45,7 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCardList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCards().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, commandHistory, Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
@@ -55,12 +55,12 @@ public class DeleteCommandTest {
     public void execute_validIndexFilteredList_success() {
         showCardAtIndex(model, INDEX_FIRST_CARD);
 
-        Card cardToDelete = model.getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased());
+        Card cardToDelete = model.getFilteredCards().get(INDEX_FIRST_CARD.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_CARD);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CARD_SUCCESS, cardToDelete);
 
-        Model expectedModel = new ModelManager(model.getCardFolder(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getCardFolders(), new UserPrefs());
         expectedModel.deleteCard(cardToDelete);
         expectedModel.commitCardFolder();
         showNoCard(expectedModel);
@@ -74,7 +74,7 @@ public class DeleteCommandTest {
 
         Index outOfBoundIndex = INDEX_SECOND_CARD;
         // ensures that outOfBoundIndex is still in bounds of card folder list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getCardFolder().getCardList().size());
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getActiveCardFolder().getCardList().size());
 
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
@@ -83,9 +83,9 @@ public class DeleteCommandTest {
 
     @Test
     public void executeUndoRedo_validIndexUnfilteredList_success() throws Exception {
-        Card cardToDelete = model.getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased());
+        Card cardToDelete = model.getFilteredCards().get(INDEX_FIRST_CARD.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_CARD);
-        Model expectedModel = new ModelManager(model.getCardFolder(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getCardFolders(), new UserPrefs());
         expectedModel.deleteCard(cardToDelete);
         expectedModel.commitCardFolder();
 
@@ -103,7 +103,7 @@ public class DeleteCommandTest {
 
     @Test
     public void executeUndoRedo_invalidIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCardList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCards().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
         // execution failed -> card folder state not added into model
@@ -124,10 +124,10 @@ public class DeleteCommandTest {
     @Test
     public void executeUndoRedo_validIndexFilteredList_sameCardDeleted() throws Exception {
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_CARD);
-        Model expectedModel = new ModelManager(model.getCardFolder(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getCardFolders(), new UserPrefs());
 
         showCardAtIndex(model, INDEX_SECOND_CARD);
-        Card cardToDelete = model.getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased());
+        Card cardToDelete = model.getFilteredCards().get(INDEX_FIRST_CARD.getZeroBased());
         expectedModel.deleteCard(cardToDelete);
         expectedModel.commitCardFolder();
 
@@ -138,7 +138,7 @@ public class DeleteCommandTest {
         expectedModel.undoCardFolder();
         assertCommandSuccess(new UndoCommand(), model, commandHistory, UndoCommand.MESSAGE_SUCCESS, expectedModel);
 
-        assertNotEquals(cardToDelete, model.getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased()));
+        assertNotEquals(cardToDelete, model.getFilteredCards().get(INDEX_FIRST_CARD.getZeroBased()));
         // redo -> deletes same second card in unfiltered card list
         expectedModel.redoCardFolder();
         assertCommandSuccess(new RedoCommand(), model, commandHistory, RedoCommand.MESSAGE_SUCCESS, expectedModel);
@@ -170,8 +170,8 @@ public class DeleteCommandTest {
      * Updates {@code model}'s filtered list to show no one.
      */
     private void showNoCard(Model model) {
-        model.updateFilteredCardList(p -> false);
+        model.updateFilteredCard(p -> false);
 
-        assertTrue(model.getFilteredCardList().isEmpty());
+        assertTrue(model.getFilteredCards().isEmpty());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -11,9 +11,11 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showCardAtIndex;
-import static seedu.address.testutil.TypicalCards.getTypicalCardFolder;
+import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CARD;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CARD;
+
+import java.util.Collections;
 
 import org.junit.Test;
 
@@ -34,7 +36,7 @@ import seedu.address.testutil.EditCardDescriptorBuilder;
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(getTypicalCardFolder(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalCardFolders(), new UserPrefs());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test
@@ -45,8 +47,9 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CARD_SUCCESS, editedCard);
 
-        Model expectedModel = new ModelManager(new CardFolder(model.getCardFolder()), new UserPrefs());
-        expectedModel.setCard(model.getFilteredCardList().get(0), editedCard);
+        Model expectedModel = new ModelManager(Collections.singletonList(new CardFolder(model.getActiveCardFolder())),
+                new UserPrefs());
+        expectedModel.setCard(model.getFilteredCards().get(0), editedCard);
         expectedModel.commitCardFolder();
 
         assertCommandSuccess(editCommand, model, commandHistory, expectedMessage, expectedModel);
@@ -54,8 +57,8 @@ public class EditCommandTest {
 
     @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
-        Index indexLastCard = Index.fromOneBased(model.getFilteredCardList().size());
-        Card lastCard = model.getFilteredCardList().get(indexLastCard.getZeroBased());
+        Index indexLastCard = Index.fromOneBased(model.getFilteredCards().size());
+        Card lastCard = model.getFilteredCards().get(indexLastCard.getZeroBased());
 
         CardBuilder cardInList = new CardBuilder(lastCard);
         Card editedCard = cardInList.withQuestion(VALID_QUESTION_BOB).withAnswer(VALID_ANSWER_BOB)
@@ -67,7 +70,8 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CARD_SUCCESS, editedCard);
 
-        Model expectedModel = new ModelManager(new CardFolder(model.getCardFolder()), new UserPrefs());
+        Model expectedModel = new ModelManager(Collections.singletonList(new CardFolder(model.getActiveCardFolder())),
+                new UserPrefs());
         expectedModel.setCard(lastCard, editedCard);
         expectedModel.commitCardFolder();
 
@@ -77,11 +81,12 @@ public class EditCommandTest {
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_CARD, new EditCommand.EditCardDescriptor());
-        Card editedCard = model.getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased());
+        Card editedCard = model.getFilteredCards().get(INDEX_FIRST_CARD.getZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CARD_SUCCESS, editedCard);
 
-        Model expectedModel = new ModelManager(new CardFolder(model.getCardFolder()), new UserPrefs());
+        Model expectedModel = new ModelManager(Collections.singletonList(new CardFolder(model.getActiveCardFolder())),
+                new UserPrefs());
         expectedModel.commitCardFolder();
 
         assertCommandSuccess(editCommand, model, commandHistory, expectedMessage, expectedModel);
@@ -91,15 +96,16 @@ public class EditCommandTest {
     public void execute_filteredList_success() {
         showCardAtIndex(model, INDEX_FIRST_CARD);
 
-        Card cardInFilteredList = model.getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased());
+        Card cardInFilteredList = model.getFilteredCards().get(INDEX_FIRST_CARD.getZeroBased());
         Card editedCard = new CardBuilder(cardInFilteredList).withQuestion(VALID_QUESTION_BOB).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_CARD,
                 new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CARD_SUCCESS, editedCard);
 
-        Model expectedModel = new ModelManager(new CardFolder(model.getCardFolder()), new UserPrefs());
-        expectedModel.setCard(model.getFilteredCardList().get(0), editedCard);
+        Model expectedModel = new ModelManager(Collections.singletonList(new CardFolder(model.getActiveCardFolder())),
+                new UserPrefs());
+        expectedModel.setCard(model.getFilteredCards().get(0), editedCard);
         expectedModel.commitCardFolder();
 
         assertCommandSuccess(editCommand, model, commandHistory, expectedMessage, expectedModel);
@@ -107,7 +113,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicateCardUnfilteredList_failure() {
-        Card firstCard = model.getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased());
+        Card firstCard = model.getFilteredCards().get(INDEX_FIRST_CARD.getZeroBased());
         EditCardDescriptor descriptor = new EditCardDescriptorBuilder(firstCard).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_CARD, descriptor);
 
@@ -119,7 +125,7 @@ public class EditCommandTest {
         showCardAtIndex(model, INDEX_FIRST_CARD);
 
         // edit card in filtered list into a duplicate in card folder
-        Card cardInList = model.getCardFolder().getCardList().get(INDEX_SECOND_CARD.getZeroBased());
+        Card cardInList = model.getActiveCardFolder().getCardList().get(INDEX_SECOND_CARD.getZeroBased());
         EditCommand editCommand = new EditCommand(INDEX_FIRST_CARD,
                 new EditCardDescriptorBuilder(cardInList).build());
 
@@ -128,7 +134,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_invalidCardIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCardList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCards().size() + 1);
         EditCommand.EditCardDescriptor descriptor =
                 new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
@@ -145,7 +151,7 @@ public class EditCommandTest {
         showCardAtIndex(model, INDEX_FIRST_CARD);
         Index outOfBoundIndex = INDEX_SECOND_CARD;
         // ensures that outOfBoundIndex is still in bounds of card folder list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getCardFolder().getCardList().size());
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getActiveCardFolder().getCardList().size());
 
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
                 new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_BOB).build());
@@ -156,10 +162,11 @@ public class EditCommandTest {
     @Test
     public void executeUndoRedo_validIndexUnfilteredList_success() throws Exception {
         Card editedCard = new CardBuilder().build();
-        Card cardToEdit = model.getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased());
+        Card cardToEdit = model.getFilteredCards().get(INDEX_FIRST_CARD.getZeroBased());
         EditCommand.EditCardDescriptor descriptor = new EditCardDescriptorBuilder(editedCard).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_CARD, descriptor);
-        Model expectedModel = new ModelManager(new CardFolder(model.getCardFolder()), new UserPrefs());
+        Model expectedModel = new ModelManager(Collections.singletonList(new CardFolder(model.getActiveCardFolder())),
+                new UserPrefs());
         expectedModel.setCard(cardToEdit, editedCard);
         expectedModel.commitCardFolder();
 
@@ -177,7 +184,7 @@ public class EditCommandTest {
 
     @Test
     public void executeUndoRedo_invalidIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCardList().size() + 1);
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCards().size() + 1);
         EditCommand.EditCardDescriptor descriptor = new EditCardDescriptorBuilder()
                 .withQuestion(VALID_QUESTION_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
@@ -202,10 +209,11 @@ public class EditCommandTest {
         Card editedCard = new CardBuilder().build();
         EditCardDescriptor descriptor = new EditCardDescriptorBuilder(editedCard).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_CARD, descriptor);
-        Model expectedModel = new ModelManager(new CardFolder(model.getCardFolder()), new UserPrefs());
+        Model expectedModel = new ModelManager(Collections.singletonList(new CardFolder(model.getActiveCardFolder())),
+                new UserPrefs());
 
         showCardAtIndex(model, INDEX_SECOND_CARD);
-        Card cardToEdit = model.getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased());
+        Card cardToEdit = model.getFilteredCards().get(INDEX_FIRST_CARD.getZeroBased());
         expectedModel.setCard(cardToEdit, editedCard);
         expectedModel.commitCardFolder();
 
@@ -216,7 +224,7 @@ public class EditCommandTest {
         expectedModel.undoCardFolder();
         assertCommandSuccess(new UndoCommand(), model, commandHistory, UndoCommand.MESSAGE_SUCCESS, expectedModel);
 
-        assertNotEquals(model.getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased()), cardToEdit);
+        assertNotEquals(model.getFilteredCards().get(INDEX_FIRST_CARD.getZeroBased()), cardToEdit);
         // redo -> edits same second card in unfiltered card list
         expectedModel.redoCardFolder();
         assertCommandSuccess(new RedoCommand(), model, commandHistory, RedoCommand.MESSAGE_SUCCESS, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -8,7 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalCards.CARL;
 import static seedu.address.testutil.TypicalCards.ELLE;
 import static seedu.address.testutil.TypicalCards.FIONA;
-import static seedu.address.testutil.TypicalCards.getTypicalCardFolder;
+import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,8 +25,8 @@ import seedu.address.model.card.QuestionContainsKeywordsPredicate;
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class FindCommandTest {
-    private Model model = new ModelManager(getTypicalCardFolder(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalCardFolder(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalCardFolders(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalCardFolders(), new UserPrefs());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test
@@ -61,9 +61,9 @@ public class FindCommandTest {
         String expectedMessage = String.format(MESSAGE_CARDS_LISTED_OVERVIEW, 0);
         QuestionContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredCardList(predicate);
+        expectedModel.updateFilteredCard(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredCardList());
+        assertEquals(Collections.emptyList(), model.getFilteredCards());
     }
 
     @Test
@@ -71,9 +71,9 @@ public class FindCommandTest {
         String expectedMessage = String.format(MESSAGE_CARDS_LISTED_OVERVIEW, 3);
         QuestionContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredCardList(predicate);
+        expectedModel.updateFilteredCard(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredCardList());
+        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredCards());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showCardAtIndex;
-import static seedu.address.testutil.TypicalCards.getTypicalCardFolder;
+import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CARD;
 
 import org.junit.Before;
@@ -24,8 +24,8 @@ public class ListCommandTest {
 
     @Before
     public void setUp() {
-        model = new ModelManager(getTypicalCardFolder(), new UserPrefs());
-        expectedModel = new ModelManager(model.getCardFolder(), new UserPrefs());
+        model = new ModelManager(getTypicalCardFolders(), new UserPrefs());
+        expectedModel = new ModelManager(model.getCardFolders(), new UserPrefs());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.deleteFirstCard;
-import static seedu.address.testutil.TypicalCards.getTypicalCardFolder;
+import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -15,8 +15,8 @@ import seedu.address.model.UserPrefs;
 
 public class RedoCommandTest {
 
-    private final Model model = new ModelManager(getTypicalCardFolder(), new UserPrefs());
-    private final Model expectedModel = new ModelManager(getTypicalCardFolder(), new UserPrefs());
+    private final Model model = new ModelManager(getTypicalCardFolders(), new UserPrefs());
+    private final Model expectedModel = new ModelManager(getTypicalCardFolders(), new UserPrefs());
     private final CommandHistory commandHistory = new CommandHistory();
 
     @Before

--- a/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showCardAtIndex;
-import static seedu.address.testutil.TypicalCards.getTypicalCardFolder;
+import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CARD;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CARD;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_CARD;
@@ -23,13 +23,13 @@ import seedu.address.model.UserPrefs;
  * Contains integration tests (interaction with the Model) for {@code SelectCommand}.
  */
 public class SelectCommandTest {
-    private Model model = new ModelManager(getTypicalCardFolder(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalCardFolder(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalCardFolders(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalCardFolders(), new UserPrefs());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
-        Index lastCardIndex = Index.fromOneBased(model.getFilteredCardList().size());
+        Index lastCardIndex = Index.fromOneBased(model.getFilteredCards().size());
 
         assertExecutionSuccess(INDEX_FIRST_CARD);
         assertExecutionSuccess(INDEX_THIRD_CARD);
@@ -38,7 +38,7 @@ public class SelectCommandTest {
 
     @Test
     public void execute_invalidIndexUnfilteredList_failure() {
-        Index outOfBoundsIndex = Index.fromOneBased(model.getFilteredCardList().size() + 1);
+        Index outOfBoundsIndex = Index.fromOneBased(model.getFilteredCards().size() + 1);
 
         assertExecutionFailure(outOfBoundsIndex, Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
     }
@@ -58,7 +58,7 @@ public class SelectCommandTest {
 
         Index outOfBoundsIndex = INDEX_SECOND_CARD;
         // ensures that outOfBoundIndex is still in bounds of card folder list
-        assertTrue(outOfBoundsIndex.getZeroBased() < model.getCardFolder().getCardList().size());
+        assertTrue(outOfBoundsIndex.getZeroBased() < model.getActiveCardFolder().getCardList().size());
 
         assertExecutionFailure(outOfBoundsIndex, Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
     }
@@ -92,7 +92,7 @@ public class SelectCommandTest {
     private void assertExecutionSuccess(Index index) {
         SelectCommand selectCommand = new SelectCommand(index);
         String expectedMessage = String.format(SelectCommand.MESSAGE_SELECT_CARD_SUCCESS, index.getOneBased());
-        expectedModel.setSelectedCard(model.getFilteredCardList().get(index.getZeroBased()));
+        expectedModel.setSelectedCard(model.getFilteredCards().get(index.getZeroBased()));
 
         assertCommandSuccess(selectCommand, model, commandHistory, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.deleteFirstCard;
-import static seedu.address.testutil.TypicalCards.getTypicalCardFolder;
+import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -15,8 +15,8 @@ import seedu.address.model.UserPrefs;
 
 public class UndoCommandTest {
 
-    private final Model model = new ModelManager(getTypicalCardFolder(), new UserPrefs());
-    private final Model expectedModel = new ModelManager(getTypicalCardFolder(), new UserPrefs());
+    private final Model model = new ModelManager(getTypicalCardFolders(), new UserPrefs());
+    private final Model expectedModel = new ModelManager(getTypicalCardFolders(), new UserPrefs());
     private final CommandHistory commandHistory = new CommandHistory();
 
     @Before

--- a/src/test/java/seedu/address/model/CardFolderTest.java
+++ b/src/test/java/seedu/address/model/CardFolderTest.java
@@ -129,6 +129,11 @@ public class CardFolderTest {
         }
 
         @Override
+        public String getFolderName() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void addListener(InvalidationListener listener) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -48,14 +48,14 @@ public class ModelManagerTest {
     @Test
     public void setUserPrefs_validUserPrefs_copiesUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setCardFolderFilePath(Paths.get("address/book/file/path"));
+        userPrefs.setcardFolderFilesPath(Paths.get("address/book/file/path"));
         userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4));
         modelManager.setUserPrefs(userPrefs);
         assertEquals(userPrefs, modelManager.getUserPrefs());
 
         // Modifying userPrefs should not modify modelManager's userPrefs
         UserPrefs oldUserPrefs = new UserPrefs(userPrefs);
-        userPrefs.setCardFolderFilePath(Paths.get("new/address/book/file/path"));
+        userPrefs.setcardFolderFilesPath(Paths.get("new/address/book/file/path"));
         assertEquals(oldUserPrefs, modelManager.getUserPrefs());
     }
 
@@ -73,16 +73,16 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void setCardFolderFilePath_nullPath_throwsNullPointerException() {
+    public void setcardFolderFilesPath_nullPath_throwsNullPointerException() {
         thrown.expect(NullPointerException.class);
-        modelManager.setCardFolderFilePath(null);
+        modelManager.setcardFolderFilesPath(null);
     }
 
     @Test
-    public void setCardFolderFilePath_validPath_setsCardFolderFilePath() {
+    public void setcardFolderFilesPath_validPath_setscardFolderFilesPath() {
         Path path = Paths.get("address/book/file/path");
-        modelManager.setCardFolderFilePath(path);
-        assertEquals(path, modelManager.getCardFolderFilePath());
+        modelManager.setcardFolderFilesPath(path);
+        assertEquals(path, modelManager.getcardFolderFilesPath());
     }
 
     @Test
@@ -182,7 +182,7 @@ public class ModelManagerTest {
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();
-        differentUserPrefs.setCardFolderFilePath(Paths.get("differentFilePath"));
+        differentUserPrefs.setcardFolderFilesPath(Paths.get("differentFilePath"));
         assertFalse(modelManager.equals(new ModelManager(cardFolder, differentUserPrefs)));
     }
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -35,7 +35,7 @@ public class ModelManagerTest {
     public void constructor() {
         assertEquals(new UserPrefs(), modelManager.getUserPrefs());
         assertEquals(new GuiSettings(), modelManager.getGuiSettings());
-        assertEquals(new CardFolder(), new CardFolder(modelManager.getCardFolder()));
+        assertEquals(new CardFolder(), new CardFolder(modelManager.getActiveCardFolder()));
         assertEquals(null, modelManager.getSelectedCard());
     }
 
@@ -114,7 +114,7 @@ public class ModelManagerTest {
     public void deleteCard_cardIsSelectedAndSecondCardInFilteredCardList_firstCardSelected() {
         modelManager.addCard(ALICE);
         modelManager.addCard(BOB);
-        assertEquals(Arrays.asList(ALICE, BOB), modelManager.getFilteredCardList());
+        assertEquals(Arrays.asList(ALICE, BOB), modelManager.getFilteredCards());
         modelManager.setSelectedCard(BOB);
         modelManager.deleteCard(BOB);
         assertEquals(ALICE, modelManager.getSelectedCard());
@@ -132,7 +132,7 @@ public class ModelManagerTest {
     @Test
     public void getFilteredCardList_modifyList_throwsUnsupportedOperationException() {
         thrown.expect(UnsupportedOperationException.class);
-        modelManager.getFilteredCardList().remove(0);
+        modelManager.getFilteredCards().remove(0);
     }
 
     @Test
@@ -144,7 +144,7 @@ public class ModelManagerTest {
     @Test
     public void setSelectedCard_cardInFilteredCardList_setsSelectedCard() {
         modelManager.addCard(ALICE);
-        assertEquals(Collections.singletonList(ALICE), modelManager.getFilteredCardList());
+        assertEquals(Collections.singletonList(ALICE), modelManager.getFilteredCards());
         modelManager.setSelectedCard(ALICE);
         assertEquals(ALICE, modelManager.getSelectedCard());
     }
@@ -156,8 +156,8 @@ public class ModelManagerTest {
         UserPrefs userPrefs = new UserPrefs();
 
         // same values -> returns true
-        modelManager = new ModelManager(cardFolder, userPrefs);
-        ModelManager modelManagerCopy = new ModelManager(cardFolder, userPrefs);
+        modelManager = new ModelManager(Collections.singletonList(cardFolder), userPrefs);
+        ModelManager modelManagerCopy = new ModelManager(Collections.singletonList(cardFolder), userPrefs);
         assertTrue(modelManager.equals(modelManagerCopy));
 
         // same object -> returns true
@@ -170,19 +170,19 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(5));
 
         // different cardFolder -> returns false
-        assertFalse(modelManager.equals(new ModelManager(differentCardFolder, userPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(Collections.singletonList(differentCardFolder), userPrefs)));
 
         // different filteredList -> returns false
         String[] keywords = ALICE.getQuestion().fullQuestion.split("\\s+");
-        modelManager.updateFilteredCardList(new QuestionContainsKeywordsPredicate(Arrays.asList(keywords)));
-        assertFalse(modelManager.equals(new ModelManager(cardFolder, userPrefs)));
+        modelManager.updateFilteredCard(new QuestionContainsKeywordsPredicate(Arrays.asList(keywords)));
+        assertFalse(modelManager.equals(new ModelManager(Collections.singletonList(cardFolder), userPrefs)));
 
         // resets modelManager to initial state for upcoming tests
-        modelManager.updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
+        modelManager.updateFilteredCard(PREDICATE_SHOW_ALL_CARDS);
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();
         differentUserPrefs.setcardFolderFilesPath(Paths.get("differentFilePath"));
-        assertFalse(modelManager.equals(new ModelManager(cardFolder, differentUserPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(Collections.singletonList(cardFolder), differentUserPrefs)));
     }
 }

--- a/src/test/java/seedu/address/model/UserPrefsTest.java
+++ b/src/test/java/seedu/address/model/UserPrefsTest.java
@@ -13,9 +13,9 @@ public class UserPrefsTest {
     }
 
     @Test
-    public void setCardFolderFilePath_nullPath_throwsNullPointerException() {
+    public void setcardFolderFilesPath_nullPath_throwsNullPointerException() {
         UserPrefs userPrefs = new UserPrefs();
-        Assert.assertThrows(NullPointerException.class, () -> userPrefs.setCardFolderFilePath(null));
+        Assert.assertThrows(NullPointerException.class, () -> userPrefs.setcardFolderFilesPath(null));
     }
 
 }

--- a/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
@@ -83,7 +83,7 @@ public class JsonUserPrefsStorageTest {
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100));
-        userPrefs.setCardFolderFilePath(Paths.get("cardfolder.json"));
+        userPrefs.setcardFolderFilesPath(Paths.get("cardfolder.json"));
         return userPrefs;
     }
 

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertNotNull;
 import static seedu.address.testutil.TypicalCards.getTypicalCardFolder;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -26,8 +28,11 @@ public class StorageManagerTest {
     @Before
     public void setUp() {
         JsonCardFolderStorage cardFolderStorage = new JsonCardFolderStorage(getTempFilePath("ab"));
+        List<CardFolderStorage> cardFolderStorageList = new ArrayList<>();
+        // TODO: Iterate over all files in directory
+        cardFolderStorageList.add(cardFolderStorage);
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("prefs"));
-        storageManager = new StorageManager(cardFolderStorage, userPrefsStorage);
+        storageManager = new StorageManager(cardFolderStorageList, userPrefsStorage);
     }
 
     private Path getTempFilePath(String fileName) {
@@ -63,8 +68,8 @@ public class StorageManagerTest {
     }
 
     @Test
-    public void getCardFolderFilePath() {
-        assertNotNull(storageManager.getCardFolderFilePath());
+    public void getcardFolderFilesPath() {
+        assertNotNull(storageManager.getcardFolderFilesPath());
     }
 
 }

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -63,7 +63,8 @@ public class StorageManagerTest {
          */
         CardFolder original = getTypicalCardFolder();
         storageManager.saveCardFolder(original);
-        ReadOnlyCardFolder retrieved = storageManager.readCardFolder().get();
+        // TODO: Address hardcoding in the following line
+        ReadOnlyCardFolder retrieved = storageManager.readCardFolders().get(0);
         assertEquals(original, new CardFolder(retrieved));
     }
 

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -36,20 +36,20 @@ public class TestUtil {
      * Returns the middle index of the card in the {@code model}'s card list.
      */
     public static Index getMidIndex(Model model) {
-        return Index.fromOneBased(model.getFilteredCardList().size() / 2);
+        return Index.fromOneBased(model.getFilteredCards().size() / 2);
     }
 
     /**
      * Returns the last index of the card in the {@code model}'s card list.
      */
     public static Index getLastIndex(Model model) {
-        return Index.fromOneBased(model.getFilteredCardList().size());
+        return Index.fromOneBased(model.getFilteredCards().size());
     }
 
     /**
      * Returns the card in the {@code model}'s card list at {@code index}.
      */
     public static Card getCard(Model model, Index index) {
-        return model.getFilteredCardList().get(index.getZeroBased());
+        return model.getFilteredCards().get(index.getZeroBased());
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalCards.java
+++ b/src/test/java/seedu/address/testutil/TypicalCards.java
@@ -13,9 +13,11 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import seedu.address.model.CardFolder;
+import seedu.address.model.ReadOnlyCardFolder;
 import seedu.address.model.card.Card;
 
 /**
@@ -58,6 +60,11 @@ public class TypicalCards {
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 
     private TypicalCards() {} // prevents instantiation
+
+    // TODO: Add more folders
+    public static List<ReadOnlyCardFolder> getTypicalCardFolders() {
+        return Collections.singletonList(getTypicalCardFolder());
+    }
 
     /**
      * Returns an {@code CardFolder} with all the typical cards.

--- a/src/test/java/seedu/address/ui/MainWindowCloseTest.java
+++ b/src/test/java/seedu/address/ui/MainWindowCloseTest.java
@@ -3,7 +3,9 @@ package seedu.address.ui;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -17,6 +19,7 @@ import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 import seedu.address.logic.LogicManager;
 import seedu.address.model.ModelManager;
+import seedu.address.storage.CardFolderStorage;
 import seedu.address.storage.JsonCardFolderStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.StorageManager;
@@ -35,8 +38,11 @@ public class MainWindowCloseTest extends GuiUnitTest {
     @Before
     public void setUp() throws Exception {
         JsonCardFolderStorage jsonCardFolderStorage = new JsonCardFolderStorage(temporaryFolder.newFile().toPath());
+        List<CardFolderStorage> jsonCardFolderStorageList = new ArrayList<>();
+        // TODO: Iterate over all files in directory
+        jsonCardFolderStorageList.add(jsonCardFolderStorage);
         JsonUserPrefsStorage jsonUserPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.newFile().toPath());
-        StorageManager storageManager = new StorageManager(jsonCardFolderStorage, jsonUserPrefsStorage);
+        StorageManager storageManager = new StorageManager(jsonCardFolderStorageList, jsonUserPrefsStorage);
         FxToolkit.setupStage(stage -> {
             this.stage = stage;
             mainWindow = new MainWindow(stage, new LogicManager(new ModelManager(), storageManager));

--- a/src/test/java/systemtests/CardFolderSystemTest.java
+++ b/src/test/java/systemtests/CardFolderSystemTest.java
@@ -138,7 +138,7 @@ public abstract class CardFolderSystemTest {
      */
     protected void showAllCards() {
         executeCommand(ListCommand.COMMAND_WORD);
-        assertEquals(getModel().getCardFolder().getCardList().size(), getModel().getFilteredCardList().size());
+        assertEquals(getModel().getActiveCardFolder().getCardList().size(), getModel().getFilteredCards().size());
     }
 
     /**
@@ -146,7 +146,7 @@ public abstract class CardFolderSystemTest {
      */
     protected void showCardsWithQuestion(String keyword) {
         executeCommand(FindCommand.COMMAND_WORD + " " + keyword);
-        assertTrue(getModel().getFilteredCardList().size() < getModel().getCardFolder().getCardList().size());
+        assertTrue(getModel().getFilteredCards().size() < getModel().getActiveCardFolder().getCardList().size());
     }
 
     /**
@@ -162,7 +162,7 @@ public abstract class CardFolderSystemTest {
      */
     protected void deleteAllCards() {
         executeCommand(ClearCommand.COMMAND_WORD);
-        assertEquals(0, getModel().getCardFolder().getCardList().size());
+        assertEquals(0, getModel().getActiveCardFolder().getCardList().size());
     }
 
     /**
@@ -174,8 +174,8 @@ public abstract class CardFolderSystemTest {
             Model expectedModel) {
         assertEquals(expectedCommandInput, getCommandBox().getInput());
         assertEquals(expectedResultMessage, getResultDisplay().getText());
-        assertEquals(new CardFolder(expectedModel.getCardFolder()), testApp.readStorageCardFolder());
-        assertListMatching(getCardListPanel(), expectedModel.getFilteredCardList());
+        assertEquals(new CardFolder(expectedModel.getActiveCardFolder()), testApp.readStorageCardFolder());
+        assertListMatching(getCardListPanel(), expectedModel.getFilteredCards());
     }
 
     /**
@@ -271,7 +271,7 @@ public abstract class CardFolderSystemTest {
     private void assertApplicationStartingStateIsCorrect() {
         assertEquals("", getCommandBox().getInput());
         assertEquals("", getResultDisplay().getText());
-        assertListMatching(getCardListPanel(), getModel().getFilteredCardList());
+        assertListMatching(getCardListPanel(), getModel().getFilteredCards());
         assertEquals(BrowserPanel.DEFAULT_PAGE, getBrowserPanel().getLoadedUrl());
         assertEquals(Paths.get(".").resolve(testApp.getStorageSaveLocation()).toString(),
                 getStatusBarFooter().getSaveLocation());

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -62,14 +62,14 @@ public class DeleteCommandSystemTest extends CardFolderSystemTest {
         /* Case: filtered card list, delete index within bounds of card folder and card list -> deleted */
         showCardsWithQuestion(KEYWORD_MATCHING_MEIER);
         Index index = INDEX_FIRST_CARD;
-        assertTrue(index.getZeroBased() < getModel().getFilteredCardList().size());
+        assertTrue(index.getZeroBased() < getModel().getFilteredCards().size());
         assertCommandSuccess(index);
 
         /* Case: filtered card list, delete index within bounds of card folder but out of bounds of card list
          * -> rejected
          */
         showCardsWithQuestion(KEYWORD_MATCHING_MEIER);
-        int invalidIndex = getModel().getCardFolder().getCardList().size();
+        int invalidIndex = getModel().getActiveCardFolder().getCardList().size();
         command = DeleteCommand.COMMAND_WORD + " " + invalidIndex;
         assertCommandFailure(command, MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
 
@@ -98,7 +98,7 @@ public class DeleteCommandSystemTest extends CardFolderSystemTest {
 
         /* Case: invalid index (size + 1) -> rejected */
         Index outOfBoundsIndex = Index.fromOneBased(
-                getModel().getCardFolder().getCardList().size() + 1);
+                getModel().getActiveCardFolder().getCardList().size() + 1);
         command = DeleteCommand.COMMAND_WORD + " " + outOfBoundsIndex.getOneBased();
         assertCommandFailure(command, MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
 

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -73,7 +73,7 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
         /* Case: redo editing the last card in the list -> last card edited again */
         command = RedoCommand.COMMAND_WORD;
         expectedResultMessage = RedoCommand.MESSAGE_SUCCESS;
-        model.setCard(getModel().getFilteredCardList().get(INDEX_FIRST_CARD.getZeroBased()), editedCard);
+        model.setCard(getModel().getFilteredCards().get(INDEX_FIRST_CARD.getZeroBased()), editedCard);
         assertCommandSuccess(command, model, expectedResultMessage);
 
         /* Case: edit a card with new values same as existing values -> edited */
@@ -83,9 +83,9 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
         assertCommandSuccess(command, index, BOB);
 
         /* Case: edit a card with new values same as another card's values but with different question -> edited */
-        assertTrue(getModel().getCardFolder().getCardList().contains(BOB));
+        assertTrue(getModel().getActiveCardFolder().getCardList().contains(BOB));
         index = INDEX_SECOND_CARD;
-        assertNotEquals(getModel().getFilteredCardList().get(index.getZeroBased()), BOB);
+        assertNotEquals(getModel().getFilteredCards().get(index.getZeroBased()), BOB);
         command =
                 EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_AMY + ANSWER_DESC_BOB
                         + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
@@ -105,7 +105,7 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
         /* Case: clear tags -> cleared */
         index = INDEX_FIRST_CARD;
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + " " + PREFIX_TAG.getPrefix();
-        Card cardToEdit = getModel().getFilteredCardList().get(index.getZeroBased());
+        Card cardToEdit = getModel().getFilteredCards().get(index.getZeroBased());
         editedCard = new CardBuilder(cardToEdit).withTags().build();
         assertCommandSuccess(command, index, editedCard);
 
@@ -114,9 +114,9 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
         /* Case: filtered card list, edit index within bounds of card folder and card list -> edited */
         showCardsWithQuestion(KEYWORD_MATCHING_MEIER);
         index = INDEX_FIRST_CARD;
-        assertTrue(index.getZeroBased() < getModel().getFilteredCardList().size());
+        assertTrue(index.getZeroBased() < getModel().getFilteredCards().size());
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + " " + QUESTION_DESC_BOB;
-        cardToEdit = getModel().getFilteredCardList().get(index.getZeroBased());
+        cardToEdit = getModel().getFilteredCards().get(index.getZeroBased());
         editedCard = new CardBuilder(cardToEdit).withQuestion(VALID_QUESTION_BOB).build();
         assertCommandSuccess(command, index, editedCard);
 
@@ -124,7 +124,7 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
          * -> rejected
          */
         showCardsWithQuestion(KEYWORD_MATCHING_MEIER);
-        int invalidIndex = getModel().getCardFolder().getCardList().size();
+        int invalidIndex = getModel().getActiveCardFolder().getCardList().size();
         assertCommandFailure(EditCommand.COMMAND_WORD + " " + invalidIndex + QUESTION_DESC_BOB,
                 Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
 
@@ -154,7 +154,7 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
 
         /* Case: invalid index (size + 1) -> rejected */
-        invalidIndex = getModel().getFilteredCardList().size() + 1;
+        invalidIndex = getModel().getFilteredCards().size() + 1;
         assertCommandFailure(EditCommand.COMMAND_WORD + " " + invalidIndex + QUESTION_DESC_BOB,
                 Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
 
@@ -188,9 +188,9 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
 
         /* Case: edit a card with new values same as another card's values -> rejected */
         executeCommand(CardUtil.getAddCommand(BOB));
-        assertTrue(getModel().getCardFolder().getCardList().contains(BOB));
+        assertTrue(getModel().getActiveCardFolder().getCardList().contains(BOB));
         index = INDEX_FIRST_CARD;
-        assertFalse(getModel().getFilteredCardList().get(index.getZeroBased()).equals(BOB));
+        assertFalse(getModel().getFilteredCards().get(index.getZeroBased()).equals(BOB));
         command =
                 EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_BOB + ANSWER_DESC_BOB
                         + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
@@ -244,8 +244,8 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
     private void assertCommandSuccess(String command, Index toEdit, Card editedCard,
                                       Index expectedSelectedCardIndex) {
         Model expectedModel = getModel();
-        expectedModel.setCard(expectedModel.getFilteredCardList().get(toEdit.getZeroBased()), editedCard);
-        expectedModel.updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
+        expectedModel.setCard(expectedModel.getFilteredCards().get(toEdit.getZeroBased()), editedCard);
+        expectedModel.updateFilteredCard(PREDICATE_SHOW_ALL_CARDS);
 
         assertCommandSuccess(command, expectedModel,
                 String.format(EditCommand.MESSAGE_EDIT_CARD_SUCCESS, editedCard), expectedSelectedCardIndex);
@@ -278,7 +278,7 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
     private void assertCommandSuccess(String command, Model expectedModel, String expectedResultMessage,
                                       Index expectedSelectedCardIndex) {
         executeCommand(command);
-        expectedModel.updateFilteredCardList(PREDICATE_SHOW_ALL_CARDS);
+        expectedModel.updateFilteredCard(PREDICATE_SHOW_ALL_CARDS);
         assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
         assertCommandBoxShowsDefaultStyle();
         if (expectedSelectedCardIndex != null) {

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -82,7 +82,7 @@ public class FindCommandSystemTest extends CardFolderSystemTest {
 
         /* Case: find same cards in card folder after deleting 1 of them -> 1 card found */
         executeCommand(DeleteCommand.COMMAND_WORD + " 1");
-        assertFalse(getModel().getCardFolder().getCardList().contains(BENSON));
+        assertFalse(getModel().getActiveCardFolder().getCardList().contains(BENSON));
         command = FindCommand.COMMAND_WORD + " " + KEYWORD_MATCHING_MEIER;
         expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel, DANIEL);
@@ -167,7 +167,7 @@ public class FindCommandSystemTest extends CardFolderSystemTest {
      */
     private void assertCommandSuccess(String command, Model expectedModel) {
         String expectedResultMessage = String.format(
-                MESSAGE_CARDS_LISTED_OVERVIEW, expectedModel.getFilteredCardList().size());
+                MESSAGE_CARDS_LISTED_OVERVIEW, expectedModel.getFilteredCards().size());
 
         executeCommand(command);
         assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);

--- a/src/test/java/systemtests/HelpCommandSystemTest.java
+++ b/src/test/java/systemtests/HelpCommandSystemTest.java
@@ -65,7 +65,7 @@ public class HelpCommandSystemTest extends CardFolderSystemTest {
         assertCommandBoxShowsDefaultStyle();
         assertNotEquals(HelpCommand.SHOWING_HELP_MESSAGE, getResultDisplay().getText());
         assertNotEquals(BrowserPanel.DEFAULT_PAGE, getBrowserPanel().getLoadedUrl());
-        assertListMatching(getCardListPanel(), getModel().getFilteredCardList());
+        assertListMatching(getCardListPanel(), getModel().getFilteredCards());
 
         // assert that the status bar too is updated correctly while the help window is open
         // note: the select command tested above does not update the status bar

--- a/src/test/java/systemtests/ModelHelper.java
+++ b/src/test/java/systemtests/ModelHelper.java
@@ -20,7 +20,7 @@ public class ModelHelper {
     public static void setFilteredList(Model model, List<Card> toDisplay) {
         Optional<Predicate<Card>> predicate =
                 toDisplay.stream().map(ModelHelper::getPredicateMatching).reduce(Predicate::or);
-        model.updateFilteredCardList(predicate.orElse(PREDICATE_MATCHING_NO_CARDS));
+        model.updateFilteredCard(predicate.orElse(PREDICATE_MATCHING_NO_CARDS));
     }
 
     /**

--- a/src/test/java/systemtests/SelectCommandSystemTest.java
+++ b/src/test/java/systemtests/SelectCommandSystemTest.java
@@ -58,12 +58,12 @@ public class SelectCommandSystemTest extends CardFolderSystemTest {
          * -> rejected
          */
         showCardsWithQuestion(KEYWORD_MATCHING_MEIER);
-        int invalidIndex = getModel().getCardFolder().getCardList().size();
+        int invalidIndex = getModel().getActiveCardFolder().getCardList().size();
         assertCommandFailure(SelectCommand.COMMAND_WORD + " " + invalidIndex, MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
 
         /* Case: filtered card list, select index within bounds of card folder and card list -> selected */
         Index validIndex = Index.fromOneBased(1);
-        assertTrue(validIndex.getZeroBased() < getModel().getFilteredCardList().size());
+        assertTrue(validIndex.getZeroBased() < getModel().getFilteredCards().size());
         command = SelectCommand.COMMAND_WORD + " " + validIndex.getOneBased();
         assertCommandSuccess(command, validIndex);
 
@@ -78,7 +78,7 @@ public class SelectCommandSystemTest extends CardFolderSystemTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectCommand.MESSAGE_USAGE));
 
         /* Case: invalid index (size + 1) -> rejected */
-        invalidIndex = getModel().getFilteredCardList().size() + 1;
+        invalidIndex = getModel().getFilteredCards().size() + 1;
         assertCommandFailure(SelectCommand.COMMAND_WORD + " " + invalidIndex, MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
 
         /* Case: invalid arguments (alphabets) -> rejected */


### PR DESCRIPTION
Enhanced Storage and Model components to have support for multiple CardFolders.

Notes:
- StorageManager now has a List of CardFolderStorage, compared to a single instance previously. Similarly, ModelManager now supports a List of VersionedCardFolder and List of FilteredList\<Card\>, rather than single instances previously.
- The json storage files now have an additional field `folderName`, which will be used to uniquely identify the folder. Reading and writing `folderName` is implemented.
- The logic for searching for and comparing folders based on `folderName` is yet to be implemented.
- The JUnit tests have been adapted to reflect this change, but are still testing with just a single CardFolder at the moment.
- A new term `active` is used: A CardFolder is active when a user is currently in the folder. As of now, there is a hardcoded default active CardFolder, which is the original addressbook.
- Also added a bunch of TODOs: Nothing major or breaking, please ignore them, I will address them later down the road.

My next step is to implement folder creation and deletion, and then remove the hardcoding of the active CardFolder.