### PR TITLE
Add deletefolder and change command

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -77,6 +77,10 @@ public class LogicManager implements Logic {
             } catch (IOException ioe) {
                 throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
             }
+            // re-register listeners to all card folders
+            for (ReadOnlyCardFolder cardFolder : model.getCardFolders()) {
+                cardFolder.addListener(observable -> cardFolderModified = true);
+            }
         }
 
         return commandResult;

--- a/src/main/java/seedu/address/logic/commands/AnswerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnswerCommand.java
@@ -54,10 +54,10 @@ public class AnswerCommand extends Command {
         model.updateFilteredCard(PREDICATE_SHOW_ALL_CARDS);
         model.commitActiveCardFolder();
         if (isAttemptCorrect) {
-            return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, null,
+            return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, false, null,
                     false, AnswerCommandResultType.ANSWER_CORRECT);
         } else {
-            return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, null,
+            return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, false, null,
                     false, AnswerCommandResultType.ANSWER_WRONG);
         }
     }

--- a/src/main/java/seedu/address/logic/commands/ChangeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ChangeCommand.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.AnswerCommandResultType;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyCardFolder;
+
+/**
+ * Selects a card identified using it's displayed index from the card folder.
+ */
+public class ChangeCommand extends Command {
+
+    public static final String COMMAND_WORD = "change";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Changes the card folder that the user is in.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_SELECT_CARD_SUCCESS = "Entered Card Folder: %1$s";
+
+    private final Index targetIndex;
+
+    public ChangeCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+
+        List<ReadOnlyCardFolder> cardFolderList = model.getCardFolders();
+
+        if (targetIndex.getZeroBased() >= cardFolderList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
+        }
+
+        model.setActiveCardFolderIndex(targetIndex.getZeroBased());
+        return new CommandResult(String.format(MESSAGE_SELECT_CARD_SUCCESS, targetIndex.getOneBased()),
+                false, false, true, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ChangeCommand // instanceof handles nulls
+                && targetIndex.equals(((ChangeCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -22,6 +22,9 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    /** The side panel should be updated. */
+    private final boolean sidePanelUpdated;
+
     /** The application should enter a test session. */
     private final Card testSessionCard;
 
@@ -34,11 +37,12 @@ public class CommandResult {
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, Card testSessionCard,
-                         boolean endTestSession, AnswerCommandResultType answerCommandResult) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean sidePanelUpdated,
+                         Card testSessionCard, boolean endTestSession, AnswerCommandResultType answerCommandResult) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
+        this.sidePanelUpdated = sidePanelUpdated;
         this.testSessionCard = testSessionCard;
         this.endTestSession = endTestSession;
         this.answerCommandResult = answerCommandResult;
@@ -49,7 +53,7 @@ public class CommandResult {
      * and other fields set to their default fullAnswer.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
+        this(feedbackToUser, false, false, false, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
     }
 
     public String getFeedbackToUser() {
@@ -107,6 +111,10 @@ public class CommandResult {
         } else {
             throw new CommandException(Messages.MESSAGE_INVALID_ANSWER_COMMAND);
         }
+    }
+
+    public boolean isSidePanelUpdated() throws CommandException {
+        return sidePanelUpdated;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteFolderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteFolderCommand.java
@@ -13,44 +13,45 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyCardFolder;
 
 /**
- * Selects a card identified using it's displayed index from the card folder.
+ * Deletes a folder identified using it's displayed index from the home directory.
  */
-public class ChangeCommand extends Command {
+public class DeleteFolderCommand extends Command {
 
-    public static final String COMMAND_WORD = "change";
+    public static final String COMMAND_WORD = "deletefolder";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Changes the card folder that the user is in.\n"
+            + ": Deletes the card folder identified by the index number used in the displayed list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_SELECT_FOLDER_SUCCESS = "Entered Card Folder: %1$s";
+    public static final String MESSAGE_DELETE_FOLDER_SUCCESS = "Deleted Card Folder: %1$s";
 
     private final Index targetIndex;
 
-    public ChangeCommand(Index targetIndex) {
+    public DeleteFolderCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
-
         List<ReadOnlyCardFolder> cardFolderList = model.getCardFolders();
 
         if (targetIndex.getZeroBased() >= cardFolderList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_FOLDER_DISPLAYED_INDEX);
         }
 
-        model.setActiveCardFolderIndex(targetIndex.getZeroBased());
-        return new CommandResult(String.format(MESSAGE_SELECT_FOLDER_SUCCESS, targetIndex.getOneBased()),
+        ReadOnlyCardFolder cardFolderToDelete = cardFolderList.get(targetIndex.getZeroBased());
+
+        model.deleteFolder(targetIndex.getZeroBased());
+        return new CommandResult(String.format(MESSAGE_DELETE_FOLDER_SUCCESS, cardFolderToDelete),
                 false, false, true, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof ChangeCommand // instanceof handles nulls
-                && targetIndex.equals(((ChangeCommand) other).targetIndex)); // state check
+                || (other instanceof DeleteFolderCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteFolderCommand) other).targetIndex)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EndCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EndCommand.java
@@ -22,7 +22,7 @@ public class EndCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_COMMAND_OUTSIDE_TEST_SESSION);
         }
         model.endTestSession();
-        return new CommandResult(MESSAGE_END_TEST_SESSION_SUCCESS, false, false, null, true,
+        return new CommandResult(MESSAGE_END_TEST_SESSION_SUCCESS, false, false, false, null, true,
                 AnswerCommandResultType.NOT_ANSWER_COMMAND);
     }
 

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -15,7 +15,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, null, false,
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false, null, false,
                 AnswerCommandResultType.NOT_ANSWER_COMMAND);
     }
 

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -18,7 +18,7 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, null, false,
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, null, false,
                 AnswerCommandResultType.NOT_ANSWER_COMMAND);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/TestCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TestCommand.java
@@ -49,7 +49,7 @@ public class TestCommand extends Command {
         ReadOnlyCardFolder cardFolderToTest = cardFoldersList.get(targetIndex.getZeroBased());
         model.testCardFolder(cardFolderToTest);
         Card cardToTest = model.getCurrentTestedCard();
-        return new CommandResult(MESSAGE_ENTER_TEST_FOLDER_SUCCESS, false, false, cardToTest, false,
+        return new CommandResult(MESSAGE_ENTER_TEST_FOLDER_SUCCESS, false, false, false, cardToTest, false,
                 AnswerCommandResultType.NOT_ANSWER_COMMAND);
     }
 

--- a/src/main/java/seedu/address/logic/parser/ChangeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ChangeCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ChangeCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ChangeCommand object
+ */
+public class ChangeCommandParser implements Parser<ChangeCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ChangeCommand
+     * and returns an ChangeCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ChangeCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new ChangeCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ChangeCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/CommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CommandParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.ChangeCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteFolderCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EndCommand;
 import seedu.address.logic.commands.ExitCommand;
@@ -73,6 +74,9 @@ public class CommandParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+
+        case DeleteFolderCommand.COMMAND_WORD:
+            return new DeleteFolderCommandParser().parse(arguments);
 
         case TestCommand.COMMAND_WORD:
             return new TestCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/CommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CommandParser.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddFolderCommand;
 import seedu.address.logic.commands.AnswerCommand;
+import seedu.address.logic.commands.ChangeCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -60,6 +61,9 @@ public class CommandParser {
 
         case AddFolderCommand.COMMAND_WORD:
             return new AddFolderCommandParser().parse(arguments);
+
+        case ChangeCommand.COMMAND_WORD:
+            return new ChangeCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/DeleteFolderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteFolderCommandParser.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteFolderCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteFolderCommand object
+ */
+public class DeleteFolderCommandParser implements Parser<DeleteFolderCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteFolderCommand
+     * and returns an DeleteFolderCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteFolderCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteFolderCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/CardFolder.java
+++ b/src/main/java/seedu/address/model/CardFolder.java
@@ -124,7 +124,7 @@ public class CardFolder implements ReadOnlyCardFolder {
 
     @Override
     public String toString() {
-        return cards.asUnmodifiableObservableList().size() + " cards";
+        return getFolderName();
         // TODO: refine later
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -107,6 +107,11 @@ public interface Model extends Observable {
      */
     int getActiveCardFolderIndex();
 
+    /**
+     * Sets the index of the current active {@code CardFolder}.
+     */
+    void setActiveCardFolderIndex(int newIndex);
+
     /** Returns an unmodifiable view of the filtered card list */
     ObservableList<Card> getFilteredCards();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -202,14 +202,20 @@ public class ModelManager implements Model {
 
     @Override
     public void addFolder(CardFolder cardFolder) {
-        foldersList.add(new VersionedCardFolder(cardFolder));
+        VersionedCardFolder versionedCardFolder = new VersionedCardFolder(cardFolder);
+        foldersList.add(versionedCardFolder);
+        FilteredList<Card> filteredCards = new FilteredList<>(versionedCardFolder.getCardList());
+        filteredCardsList.add(filteredCards);
+        filteredCards.addListener(this::ensureSelectedCardIsValid);
         indicateModified();
     }
 
+    @Override
     public int getActiveCardFolderIndex() {
         return activeCardFolderIndex;
     }
 
+    @Override
     public void setActiveCardFolderIndex(int newIndex) {
         activeCardFolderIndex = newIndex;
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -196,7 +196,8 @@ public class ModelManager implements Model {
 
     @Override
     public void deleteFolder(int index) {
-        filteredFoldersList.remove(index);
+        foldersList.remove(index);
+        filteredCardsList.remove(index);
         indicateModified();
     }
 

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -1,12 +1,14 @@
 package seedu.address.storage;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.DataConversionException;
@@ -90,6 +92,13 @@ public class StorageManager implements Storage {
     @Override
     public void saveCardFolders(List<ReadOnlyCardFolder> cardFolders) throws IOException {
         cardFolderStorageList.clear();
+        // Clear directory before saving
+        List<Path> pathsToDelete = Files.walk(Paths.get("data\\"))
+                .filter(Files::isRegularFile)
+                .collect(Collectors.toList());
+        for (Path pathToDelete : pathsToDelete) {
+            Files.deleteIfExists(pathToDelete);
+        }
         for (ReadOnlyCardFolder cardFolder : cardFolders) {
             // TODO: Address hardcoding and add check for orphaned folders
             Path filePath = Paths.get("data\\" + cardFolder.getFolderName() + ".json");

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -80,6 +80,7 @@ public class MainWindow extends UiPart<Stage> {
 
     /**
      * Sets the accelerator of a MenuItem.
+     *
      * @param keyCombination the KeyCombination fullAnswer of the accelerator
      */
     private void setAccelerator(MenuItem menuItem, KeyCombination keyCombination) {
@@ -172,7 +173,7 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Start test session UI.
+     * Starts test session UI.
      */
     private void handleStartTestSession(Card card) {
         Region testSessionRegion = (new TestSession(card)).getRoot();
@@ -180,11 +181,23 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * End test session and display back card main screen.
+     * Ends test session and display back card main screen.
      */
     private void handleEndTestSession() {
         fullScreenPlaceholder.getChildren().remove(fullScreenPlaceholder.getChildren().size() - 1);
     }
+
+    /**
+     * Refreshes the side panel to display the new active folder.
+     */
+    private void handleSidePanelUpdate() {
+        cardListPanel = new CardListPanel(logic.getFilteredCardList(), logic.selectedCardProperty(),
+                logic::setSelectedCard);
+        cardMainScreen = new CardMainScreen(cardListPanel, browserPanel);
+        fullScreenPlaceholder.getChildren().remove(fullScreenPlaceholder.getChildren().size() - 1);
+        fullScreenPlaceholder.getChildren().add(cardMainScreen.getRoot());
+    }
+
 
     /**
      * Show the page with correct answer.
@@ -198,6 +211,10 @@ public class MainWindow extends UiPart<Stage> {
      */
     private void handleWrongAnswer() {
         //TODO: Change UI to display wrong answer
+    }
+
+    private void updateCardListPanel() {
+        fullScreenPlaceholder.getChildren();
     }
 
     public CardListPanel getCardListPanel() {
@@ -221,6 +238,10 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult.isExit()) {
                 handleExit();
+            }
+
+            if (commandResult.isSidePanelUpdated()) {
+                handleSidePanelUpdate();
             }
 
             if (commandResult.isTestSession()) {

--- a/src/test/java/guitests/GuiRobot.java
+++ b/src/test/java/guitests/GuiRobot.java
@@ -101,7 +101,7 @@ public class GuiRobot extends FxRobot {
      *
      * @throws StageNotFoundException if the stage is not found.
      */
-    public Stage getStage(String stageTitle) {
+    public Stage getStage(String stageTitle) throws StageNotFoundException {
         Optional<Stage> targetStage = listTargetWindows().stream()
                 .filter(Stage.class::isInstance) // checks that the window is of type Stage
                 .map(Stage.class::cast)

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -228,6 +228,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void setActiveCardFolderIndex(int newIndex) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Card> getFilteredCards() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -19,7 +19,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false,
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false,
                 null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
 
         // same object -> returns true
@@ -34,25 +34,25 @@ public class CommandResultTest {
         // different feedbackToUser fullAnswer -> returns false
         assertFalse(commandResult.equals(new CommandResult("different")));
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false,
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false,
                 null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true,
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false,
                 null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
 
         // different testSessionCard value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false,
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false,
                 sampleTestCard, false, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
 
         // different endTestSession value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false,
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false,
                 null, true, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
 
         // different AnswerCommandResult value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false,
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false,
                 null, false, AnswerCommandResultType.ANSWER_CORRECT)));
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false,
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false,
                 null, false, AnswerCommandResultType.ANSWER_WRONG)));
     }
 
@@ -68,25 +68,25 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false,
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, false,
                 null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true,
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false,
                 null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
 
         // different testSessionCard value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false,
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, false,
                 sampleTestCard, false, AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
 
         // different endTestSession value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false,
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, false,
                 null, true, AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
 
         // different AnswerCommandResult value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false,
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, false,
                 null, false, AnswerCommandResultType.ANSWER_CORRECT).hashCode());
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false,
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, false,
                 null, false, AnswerCommandResultType.ANSWER_WRONG).hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -17,7 +17,7 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true,
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false,
                 null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
         assertCommandSuccess(new ExitCommand(), model, commandHistory, expectedCommandResult, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -17,7 +17,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false,
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, false,
                 null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
         assertCommandSuccess(new HelpCommand(), model, commandHistory, expectedCommandResult, expectedModel);
     }


### PR DESCRIPTION
`deletefolder` and `change` (partial functionality) have been implemented.

### `change`
At the moment, there is no concept of a home directory. As such, folders and their hidden/implicit indices exist, but we are unable to see them on the GUI. We can jump from folder to folder with `change <INDEX>`, a behaviour that will eventually be modified to executable only on the home directory.

The other half of the `change` command (returning to the home directory), will be implemented along with the home directory.
### `deletefolder`
`deletefolder <INDEX>` behaves as expected, removing the folder at the specified index. Note that if you delete a folder that is currently being displayed, the UI will not refresh itself until you execute a `change` command. As with `change`, this command will eventually only be executable from the home directory.

Do let me know if any bugs are encountered.