### PR TITLE
Add integration and junit tests for test session

### DIFF
--- a/src/main/java/seedu/address/logic/commands/TestCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TestCommand.java
@@ -46,8 +46,8 @@ public class TestCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_COMMAND_INSIDE_TEST_SESSION);
         }
 
-        ReadOnlyCardFolder cardFolderToTest = cardFoldersList.get(targetIndex.getZeroBased());
-        model.testCardFolder(cardFolderToTest);
+        model.setActiveCardFolderIndex(targetIndex.getZeroBased());
+        model.testCardFolder(targetIndex.getZeroBased());
         Card cardToTest = model.getCurrentTestedCard();
         return new CommandResult(MESSAGE_ENTER_TEST_FOLDER_SUCCESS, false, false, false, cardToTest, false,
                 AnswerCommandResultType.NOT_ANSWER_COMMAND);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -171,9 +171,9 @@ public interface Model extends Observable {
     List<ReadOnlyCardFolder> returnValidCardFolders(Set<CardFolderExport> cardFolders);
 
     /**
-     * Enters a test session using the specified card folder.
+     * Enters a test session using the specified card folder index.
      */
-    void testCardFolder(ReadOnlyCardFolder cardFolder);
+    void testCardFolder(int cardFolderToTestIndex);
 
     /**
      * Sets the current card in the test session.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -317,7 +317,6 @@ public class ModelManager implements Model {
 
     @Override
     public void testCardFolder(int cardFolderToTestIndex) {
-        setActiveCardFolderIndex(cardFolderToTestIndex);
         ObservableList<Card> currentTestedCardFolder = getActiveCardFolder().getCardList();
         Card cardToTest = currentTestedCardFolder.get(0);
         setCurrentTestedCard(cardToTest);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -316,9 +316,10 @@ public class ModelManager implements Model {
     //=========== Test Session ===========================================================================
 
     @Override
-    public void testCardFolder(ReadOnlyCardFolder cardFolderToTest) {
-        //TODO: Remove hardcoding, enter card folder and get the list of cards, enter test session mode
-        Card cardToTest = cardFolderToTest.getCardList().get(0);
+    public void testCardFolder(int cardFolderToTestIndex) {
+        setActiveCardFolderIndex(cardFolderToTestIndex);
+        ObservableList<Card> currentTestedCardFolder = getActiveCardFolder().getCardList();
+        Card cardToTest = currentTestedCardFolder.get(0);
         setCurrentTestedCard(cardToTest);
         insideTestSession = true;
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -341,6 +341,7 @@ public class ModelManager implements Model {
         insideTestSession = false;
         cardAlreadyAnswered = false;
         setCurrentTestedCard(null);
+        //TODO: exit card folder
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -37,7 +37,6 @@ public class MainWindow extends UiPart<Stage> {
     private CardListPanel cardListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
-    private TestSession testSessionScreen;
     private CardMainScreen cardMainScreen;
 
     @FXML
@@ -121,9 +120,6 @@ public class MainWindow extends UiPart<Stage> {
 
         CommandBox commandBox = new CommandBox(this::executeCommand, logic.getHistory());
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
-
-        testSessionScreen = new TestSession();
-        fullScreenPlaceholder.getChildren().add(testSessionScreen.getRoot());
 
         browserPanel = new BrowserPanel(logic.selectedCardProperty());
         cardListPanel = new CardListPanel(logic.getFilteredCardList(), logic.selectedCardProperty(),

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -3,9 +3,9 @@ package seedu.address.logic;
 import static org.junit.Assert.assertEquals;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_AMY;
-import static seedu.address.testutil.TypicalCards.AMY;
+import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_SAMPLE_1;
+import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_SAMPLE_1;
+import static seedu.address.testutil.TypicalCards.CARD_1;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -94,8 +94,8 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Execute add command
-        String addCommand = AddCommand.COMMAND_WORD + QUESTION_DESC_AMY + ANSWER_DESC_AMY;
-        Card expectedCard = new CardBuilder(AMY).withHint().build();
+        String addCommand = AddCommand.COMMAND_WORD + QUESTION_DESC_SAMPLE_1 + ANSWER_DESC_SAMPLE_1;
+        Card expectedCard = new CardBuilder(CARD_1).withHint().build();
         ModelManager expectedModel = new ModelManager(this.getClass().getName());
         expectedModel.addCard(expectedCard);
         expectedModel.commitActiveCardFolder();

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -149,7 +149,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void testCardFolder(ReadOnlyCardFolder cardFolderToTest) {
+        public void testCardFolder(int cardFolderToTestIndex) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AnswerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AnswerCommandTest.java
@@ -2,8 +2,8 @@ package seedu.address.logic.commands;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_1;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
 
@@ -29,8 +29,8 @@ public class AnswerCommandTest {
 
     @Test
     public void equals() {
-        Answer firstAttemptedAnswer = new Answer(VALID_ANSWER_AMY);
-        Answer secondAttemptedAnswer = new Answer(VALID_ANSWER_BOB);
+        Answer firstAttemptedAnswer = new Answer(VALID_ANSWER_1);
+        Answer secondAttemptedAnswer = new Answer(VALID_ANSWER_2);
 
         AnswerCommand answerFirstCommand = new AnswerCommand(firstAttemptedAnswer);
         AnswerCommand answerSecondCommand = new AnswerCommand(secondAttemptedAnswer);

--- a/src/test/java/seedu/address/logic/commands/AnswerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AnswerCommandTest.java
@@ -1,0 +1,75 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
+
+import org.junit.Test;
+
+import seedu.address.logic.AnswerCommandResultType;
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.card.Answer;
+import seedu.address.model.card.Card;
+import seedu.address.model.card.Score;
+import seedu.address.testutil.TypicalIndexes;
+
+/**
+ * Contains integration tests (interaction with the Model) and junit tests for {@code AnswerCommand}.
+ */
+public class AnswerCommandTest {
+    private Model model = new ModelManager(getTypicalCardFolders(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalCardFolders(), new UserPrefs());
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void equals() {
+        Answer firstAttemptedAnswer = new Answer(VALID_ANSWER_AMY);
+        Answer secondAttemptedAnswer = new Answer(VALID_ANSWER_BOB);
+
+        AnswerCommand answerFirstCommand = new AnswerCommand(firstAttemptedAnswer);
+        AnswerCommand answerSecondCommand = new AnswerCommand(secondAttemptedAnswer);
+
+        // same object -> returns true
+        assertTrue(answerFirstCommand.equals(answerFirstCommand));
+
+        // same values -> returns true
+        AnswerCommand answerFirstCommandCopy = new AnswerCommand(firstAttemptedAnswer);
+        assertTrue(answerFirstCommand.equals(answerFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(answerFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(answerFirstCommand.equals(null));
+
+        // different card -> returns false
+        assertFalse(answerFirstCommand.equals(answerSecondCommand));
+    }
+
+    @Test
+    public void execute_correctAnswerAttempt_markCorrect() {
+        CommandResult expectedCommandResult = new CommandResult(AnswerCommand.MESSAGE_ANSWER_SUCCESS, false,
+                false, false, null, false, AnswerCommandResultType.ANSWER_CORRECT);
+
+        model.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
+        expectedModel.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
+
+        Card testedCard = model.getCurrentTestedCard();
+        AnswerCommand answerCommand = new AnswerCommand(testedCard.getAnswer());
+
+        expectedModel.setCardAsAnswered();
+        Score newScore = new Score(testedCard.getScore().correctAttempts + 1,
+                testedCard.getScore().totalAttempts + 1);
+        expectedModel.setCard(testedCard, new Card(testedCard.getQuestion(), testedCard.getAnswer(), newScore,
+                testedCard.getHints()));
+        expectedModel.commitActiveCardFolder();
+
+        assertCommandSuccess(answerCommand, model, commandHistory, expectedCommandResult, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AnswerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AnswerCommandTest.java
@@ -2,8 +2,10 @@ package seedu.address.logic.commands;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_OUTSIDE_TEST_SESSION;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_1;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
 
@@ -71,5 +73,33 @@ public class AnswerCommandTest {
         expectedModel.commitActiveCardFolder();
 
         assertCommandSuccess(answerCommand, model, commandHistory, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_wrongAnswerAttempt_markWrong() {
+        CommandResult expectedCommandResult = new CommandResult(AnswerCommand.MESSAGE_ANSWER_SUCCESS, false,
+                false, false, null, false, AnswerCommandResultType.ANSWER_WRONG);
+
+        model.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
+        expectedModel.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
+
+        Card testedCard = model.getCurrentTestedCard();
+        AnswerCommand answerCommand = new AnswerCommand(new Answer(VALID_ANSWER_2));
+
+        expectedModel.setCardAsAnswered();
+        Score newScore = new Score(testedCard.getScore().correctAttempts,
+                testedCard.getScore().totalAttempts + 1);
+        expectedModel.setCard(testedCard, new Card(testedCard.getQuestion(), testedCard.getAnswer(), newScore,
+                testedCard.getHints()));
+        expectedModel.commitActiveCardFolder();
+
+        assertCommandSuccess(answerCommand, model, commandHistory, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidAnswerOutsideTestSession_fail() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_OUTSIDE_TEST_SESSION);
+        AnswerCommand answerCommand = new AnswerCommand(new Answer(VALID_ANSWER_2));
+        assertCommandFailure(answerCommand, model, commandHistory, expectedMessage);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AnswerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AnswerCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ANSWER_COMMAND;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_OUTSIDE_TEST_SESSION;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_1;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
@@ -100,6 +101,18 @@ public class AnswerCommandTest {
     public void execute_invalidAnswerOutsideTestSession_fail() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_OUTSIDE_TEST_SESSION);
         AnswerCommand answerCommand = new AnswerCommand(new Answer(VALID_ANSWER_2));
+        assertCommandFailure(answerCommand, model, commandHistory, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidAnswerAfterAnsweredAttempt_fail() {
+        String expectedMessage = String.format(MESSAGE_INVALID_ANSWER_COMMAND);
+        model.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
+
+        Card testedCard = model.getCurrentTestedCard();
+        AnswerCommand answerCommand = new AnswerCommand(testedCard.getAnswer());
+        model.setCardAsAnswered();
+
         assertCommandFailure(answerCommand, model, commandHistory, expectedMessage);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AnswerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AnswerCommandTest.java
@@ -51,7 +51,7 @@ public class AnswerCommandTest {
         // null -> returns false
         assertFalse(answerFirstCommand.equals(null));
 
-        // different card -> returns false
+        // different answer -> returns false
         assertFalse(answerFirstCommand.equals(answerSecondCommand));
     }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -26,10 +26,10 @@ import seedu.address.testutil.EditCardDescriptorBuilder;
  */
 public class CommandTestUtil {
 
-    public static final String VALID_QUESTION_AMY = "Amy Bee";
-    public static final String VALID_QUESTION_BOB = "Bob Choo";
-    public static final String VALID_ANSWER_AMY = "11111111";
-    public static final String VALID_ANSWER_BOB = "22222222";
+    public static final String VALID_QUESTION_1 = "Sample Question 1";
+    public static final String VALID_QUESTION_2 = "Sample Question 2";
+    public static final String VALID_ANSWER_1 = "Sample Answer 1";
+    public static final String VALID_ANSWER_2 = "Sample Answer 2";
     public static final String VALID_SCORE_AMY = "0/0";
     public static final String VALID_HINT_HUSBAND = "husband";
     public static final String VALID_HINT_FRIEND = "friend";
@@ -38,10 +38,10 @@ public class CommandTestUtil {
     public static final String VALID_FILENAME = "sample_folder.csv";
     public static final String INVALID_FILENAME = "sample_folder.json";
 
-    public static final String QUESTION_DESC_AMY = " " + PREFIX_QUESTION + VALID_QUESTION_AMY;
-    public static final String QUESTION_DESC_BOB = " " + PREFIX_QUESTION + VALID_QUESTION_BOB;
-    public static final String ANSWER_DESC_AMY = " " + PREFIX_ANSWER + VALID_ANSWER_AMY;
-    public static final String ANSWER_DESC_BOB = " " + PREFIX_ANSWER + VALID_ANSWER_BOB;
+    public static final String QUESTION_DESC_AMY = " " + PREFIX_QUESTION + VALID_QUESTION_1;
+    public static final String QUESTION_DESC_BOB = " " + PREFIX_QUESTION + VALID_QUESTION_2;
+    public static final String ANSWER_DESC_AMY = " " + PREFIX_ANSWER + VALID_ANSWER_1;
+    public static final String ANSWER_DESC_BOB = " " + PREFIX_ANSWER + VALID_ANSWER_2;
     public static final String HINT_DESC_FRIEND = " " + PREFIX_HINT + VALID_HINT_FRIEND;
     public static final String HINT_DESC_HUSBAND = " " + PREFIX_HINT + VALID_HINT_HUSBAND;
     public static final String FOLDER_DESC_SAMPLE_1 = " " + PREFIX_FOLDERNAME + VALID_FOLDER_NAME_1;
@@ -66,10 +66,10 @@ public class CommandTestUtil {
 
 
     static {
-        DESC_AMY = new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_AMY)
-                .withAnswer(VALID_ANSWER_AMY).withHint(VALID_HINT_FRIEND).build();
-        DESC_BOB = new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_BOB)
-                .withAnswer(VALID_ANSWER_BOB).withHint(VALID_HINT_HUSBAND, VALID_HINT_FRIEND).build();
+        DESC_AMY = new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_1)
+                .withAnswer(VALID_ANSWER_1).withHint(VALID_HINT_FRIEND).build();
+        DESC_BOB = new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_2)
+                .withAnswer(VALID_ANSWER_2).withHint(VALID_HINT_HUSBAND, VALID_HINT_FRIEND).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -30,7 +30,7 @@ public class CommandTestUtil {
     public static final String VALID_QUESTION_2 = "Sample Question 2";
     public static final String VALID_ANSWER_1 = "Sample Answer 1";
     public static final String VALID_ANSWER_2 = "Sample Answer 2";
-    public static final String VALID_SCORE_AMY = "0/0";
+    public static final String VALID_SCORE_1 = "0/0";
     public static final String VALID_HINT_HUSBAND = "husband";
     public static final String VALID_HINT_FRIEND = "friend";
     public static final String VALID_FOLDER_NAME_1 = "Sample Folder 1";
@@ -38,10 +38,10 @@ public class CommandTestUtil {
     public static final String VALID_FILENAME = "sample_folder.csv";
     public static final String INVALID_FILENAME = "sample_folder.json";
 
-    public static final String QUESTION_DESC_AMY = " " + PREFIX_QUESTION + VALID_QUESTION_1;
-    public static final String QUESTION_DESC_BOB = " " + PREFIX_QUESTION + VALID_QUESTION_2;
-    public static final String ANSWER_DESC_AMY = " " + PREFIX_ANSWER + VALID_ANSWER_1;
-    public static final String ANSWER_DESC_BOB = " " + PREFIX_ANSWER + VALID_ANSWER_2;
+    public static final String QUESTION_DESC_SAMPLE_1 = " " + PREFIX_QUESTION + VALID_QUESTION_1;
+    public static final String QUESTION_DESC_SAMPLE_2 = " " + PREFIX_QUESTION + VALID_QUESTION_2;
+    public static final String ANSWER_DESC_SAMPLE_1 = " " + PREFIX_ANSWER + VALID_ANSWER_1;
+    public static final String ANSWER_DESC_SAMPLE_2 = " " + PREFIX_ANSWER + VALID_ANSWER_2;
     public static final String HINT_DESC_FRIEND = " " + PREFIX_HINT + VALID_HINT_FRIEND;
     public static final String HINT_DESC_HUSBAND = " " + PREFIX_HINT + VALID_HINT_HUSBAND;
     public static final String FOLDER_DESC_SAMPLE_1 = " " + PREFIX_FOLDERNAME + VALID_FOLDER_NAME_1;

--- a/src/test/java/seedu/address/logic/commands/EditCardDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCardDescriptorTest.java
@@ -4,9 +4,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_2;
 
 import org.junit.Test;
 
@@ -35,11 +35,11 @@ public class EditCardDescriptorTest {
 
         // different question -> returns false
         EditCommand.EditCardDescriptor editedAmy =
-                new EditCardDescriptorBuilder(DESC_AMY).withQuestion(VALID_QUESTION_BOB).build();
+                new EditCardDescriptorBuilder(DESC_AMY).withQuestion(VALID_QUESTION_2).build();
         assertFalse(DESC_AMY.equals(editedAmy));
 
         // different answer -> returns false
-        editedAmy = new EditCardDescriptorBuilder(DESC_AMY).withAnswer(VALID_ANSWER_BOB).build();
+        editedAmy = new EditCardDescriptorBuilder(DESC_AMY).withAnswer(VALID_ANSWER_2).build();
         assertFalse(DESC_AMY.equals(editedAmy));
 
         // different hint -> returns false

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -5,9 +5,9 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_2;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showCardAtIndex;
@@ -61,11 +61,11 @@ public class EditCommandTest {
         Card lastCard = model.getFilteredCards().get(indexLastCard.getZeroBased());
 
         CardBuilder cardInList = new CardBuilder(lastCard);
-        Card editedCard = cardInList.withQuestion(VALID_QUESTION_BOB).withAnswer(VALID_ANSWER_BOB)
+        Card editedCard = cardInList.withQuestion(VALID_QUESTION_2).withAnswer(VALID_ANSWER_2)
                 .withHint(VALID_HINT_HUSBAND).build();
 
-        EditCardDescriptor descriptor = new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_BOB)
-                .withAnswer(VALID_ANSWER_BOB).withHint(VALID_HINT_HUSBAND).build();
+        EditCardDescriptor descriptor = new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_2)
+                .withAnswer(VALID_ANSWER_2).withHint(VALID_HINT_HUSBAND).build();
         EditCommand editCommand = new EditCommand(indexLastCard, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CARD_SUCCESS, editedCard);
@@ -97,9 +97,9 @@ public class EditCommandTest {
         showCardAtIndex(model, INDEX_FIRST_CARD);
 
         Card cardInFilteredList = model.getFilteredCards().get(INDEX_FIRST_CARD.getZeroBased());
-        Card editedCard = new CardBuilder(cardInFilteredList).withQuestion(VALID_QUESTION_BOB).build();
+        Card editedCard = new CardBuilder(cardInFilteredList).withQuestion(VALID_QUESTION_2).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_CARD,
-                new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_BOB).build());
+                new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_2).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CARD_SUCCESS, editedCard);
 
@@ -136,7 +136,7 @@ public class EditCommandTest {
     public void execute_invalidCardIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCards().size() + 1);
         EditCommand.EditCardDescriptor descriptor =
-                new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_BOB).build();
+                new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_2).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
         assertCommandFailure(editCommand, model, commandHistory, Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
@@ -154,7 +154,7 @@ public class EditCommandTest {
         assertTrue(outOfBoundIndex.getZeroBased() < model.getActiveCardFolder().getCardList().size());
 
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
-                new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_BOB).build());
+                new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_2).build());
 
         assertCommandFailure(editCommand, model, commandHistory, Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
     }
@@ -185,8 +185,8 @@ public class EditCommandTest {
     @Test
     public void executeUndoRedo_invalidIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCards().size() + 1);
-        EditCommand.EditCardDescriptor descriptor = new EditCardDescriptorBuilder()
-                .withQuestion(VALID_QUESTION_BOB).build();
+        EditCardDescriptor descriptor = new EditCardDescriptorBuilder()
+                .withQuestion(VALID_QUESTION_2).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
         // execution failed -> card folder state not added into model

--- a/src/test/java/seedu/address/logic/commands/EndCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EndCommandTest.java
@@ -15,6 +15,9 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.testutil.TypicalIndexes;
 
+/**
+ * Contains integration tests (interaction with the Model) and junit tests for {@code EndCommand}.
+ */
 public class EndCommandTest {
     private Model model = new ModelManager(getTypicalCardFolders(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalCardFolders(), new UserPrefs());

--- a/src/test/java/seedu/address/logic/commands/EndCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EndCommandTest.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_OUTSIDE_TEST_SESSION;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.EndCommand.MESSAGE_END_TEST_SESSION_SUCCESS;
+import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
+
+import org.junit.Test;
+
+import seedu.address.logic.AnswerCommandResultType;
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.testutil.TypicalIndexes;
+
+public class EndCommandTest {
+    private Model model = new ModelManager(getTypicalCardFolders(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalCardFolders(), new UserPrefs());
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void execute_endTestSession_success() {
+        model.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
+        expectedModel.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
+
+        expectedModel.endTestSession();
+
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_END_TEST_SESSION_SUCCESS, false, false,
+                false, null, true, AnswerCommandResultType.NOT_ANSWER_COMMAND);
+        assertCommandSuccess(new EndCommand(), model, commandHistory, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_endTestSession_fail() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_OUTSIDE_TEST_SESSION);
+        assertCommandFailure(new EndCommand(), model, commandHistory, expectedMessage);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
@@ -36,24 +36,24 @@ public class SearchCommandTest {
         QuestionContainsKeywordsPredicate secondPredicate =
                 new QuestionContainsKeywordsPredicate(Collections.singletonList("second"));
 
-        SearchCommand findFirstCommand = new SearchCommand(firstPredicate);
-        SearchCommand findSecondCommand = new SearchCommand(secondPredicate);
+        SearchCommand searchFirstCommand = new SearchCommand(firstPredicate);
+        SearchCommand searchSecondCommand = new SearchCommand(secondPredicate);
 
         // same object -> returns true
-        assertTrue(findFirstCommand.equals(findFirstCommand));
+        assertTrue(searchFirstCommand.equals(searchFirstCommand));
 
         // same values -> returns true
         SearchCommand findFirstCommandCopy = new SearchCommand(firstPredicate);
-        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+        assertTrue(searchFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
-        assertFalse(findFirstCommand.equals(1));
+        assertFalse(searchFirstCommand.equals(1));
 
         // null -> returns false
-        assertFalse(findFirstCommand.equals(null));
+        assertFalse(searchFirstCommand.equals(null));
 
         // different card -> returns false
-        assertFalse(findFirstCommand.equals(findSecondCommand));
+        assertFalse(searchFirstCommand.equals(searchSecondCommand));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/TestCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TestCommandTest.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_INSIDE_TEST_SESSION;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -42,5 +44,27 @@ public class TestCommandTest {
         model.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_INSIDE_TEST_SESSION);
         assertCommandFailure(testCommand, model, commandHistory, expectedMessage);
+    }
+
+    @Test
+    public void equals() {
+        TestCommand testFirstFolderCommand = new TestCommand(TypicalIndexes.INDEX_FIRST_CARD_FOLDER);
+        TestCommand testSecondFolderCommand = new TestCommand(TypicalIndexes.INDEX_SECOND_CARD_FOLDER);
+
+        // same object -> returns true
+        assertTrue(testFirstFolderCommand.equals(testFirstFolderCommand));
+
+        // same values -> returns true
+        TestCommand testFirstFolderCommandCopy = new TestCommand(TypicalIndexes.INDEX_FIRST_CARD_FOLDER);
+        assertTrue(testFirstFolderCommand.equals(testFirstFolderCommandCopy));
+
+        // different types -> returns false
+        assertFalse(testFirstFolderCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(testFirstFolderCommand.equals(null));
+
+        // different folder -> returns false
+        assertFalse(testFirstFolderCommand.equals(testSecondFolderCommand));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/TestCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TestCommandTest.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_INSIDE_TEST_SESSION;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
+
+import org.junit.Test;
+
+import seedu.address.logic.AnswerCommandResultType;
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.card.Card;
+import seedu.address.testutil.TypicalIndexes;
+
+/**
+ * Contains integration tests (interaction with the Model) and junit tests for {@code TestCommand}.
+ */
+public class TestCommandTest {
+    private Model model = new ModelManager(getTypicalCardFolders(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalCardFolders(), new UserPrefs());
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void execute_validTestCommand_success() {
+        TestCommand testCommand = new TestCommand(TypicalIndexes.INDEX_FIRST_CARD_FOLDER);
+        expectedModel.setActiveCardFolderIndex(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
+        expectedModel.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
+        Card cardToTest = expectedModel.getCurrentTestedCard();
+
+        CommandResult expectedCommandResult = new CommandResult(TestCommand.MESSAGE_ENTER_TEST_FOLDER_SUCCESS, false,
+                false, false, cardToTest, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
+        assertCommandSuccess(testCommand, model, commandHistory, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidTestCommandInsideTestSession_fail() {
+        TestCommand testCommand = new TestCommand(TypicalIndexes.INDEX_FIRST_CARD_FOLDER);
+        model.setActiveCardFolderIndex(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
+        model.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_INSIDE_TEST_SESSION);
+        assertCommandFailure(testCommand, model, commandHistory, expectedMessage);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_SAMPLE_1;
+import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_SAMPLE_2;
 import static seedu.address.logic.commands.CommandTestUtil.HINT_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.HINT_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ANSWER_DESC;
@@ -10,15 +10,15 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_HINT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_QUESTION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
-import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_SAMPLE_1;
+import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_SAMPLE_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_2;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalCards.AMY;
-import static seedu.address.testutil.TypicalCards.BOB;
+import static seedu.address.testutil.TypicalCards.CARD_1;
+import static seedu.address.testutil.TypicalCards.CARD_2;
 
 import org.junit.Test;
 
@@ -34,30 +34,30 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Card expectedCard = new CardBuilder(BOB).withHint(VALID_HINT_FRIEND).build();
+        Card expectedCard = new CardBuilder(CARD_2).withHint(VALID_HINT_FRIEND).build();
 
         // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + QUESTION_DESC_BOB + ANSWER_DESC_BOB
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + QUESTION_DESC_SAMPLE_2 + ANSWER_DESC_SAMPLE_2
                 + HINT_DESC_FRIEND, new AddCommand(expectedCard));
 
         // multiple names - last name accepted
-        assertParseSuccess(parser, QUESTION_DESC_AMY + QUESTION_DESC_BOB + ANSWER_DESC_BOB
+        assertParseSuccess(parser, QUESTION_DESC_SAMPLE_1 + QUESTION_DESC_SAMPLE_2 + ANSWER_DESC_SAMPLE_2
                 + HINT_DESC_FRIEND, new AddCommand(expectedCard));
 
         // multiple answers - last answer accepted
-        assertParseSuccess(parser, QUESTION_DESC_BOB + ANSWER_DESC_AMY + ANSWER_DESC_BOB
+        assertParseSuccess(parser, QUESTION_DESC_SAMPLE_2 + ANSWER_DESC_SAMPLE_1 + ANSWER_DESC_SAMPLE_2
                 + HINT_DESC_FRIEND, new AddCommand(expectedCard));
 
         // multiple hints - last hint accepted
-        assertParseSuccess(parser, QUESTION_DESC_BOB + ANSWER_DESC_BOB + HINT_DESC_HUSBAND
+        assertParseSuccess(parser, QUESTION_DESC_SAMPLE_2 + ANSWER_DESC_SAMPLE_2 + HINT_DESC_HUSBAND
                 + HINT_DESC_FRIEND, new AddCommand(expectedCard));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero hints
-        Card expectedCard = new CardBuilder(AMY).withHint().build();
-        assertParseSuccess(parser, QUESTION_DESC_AMY + ANSWER_DESC_AMY, new AddCommand(expectedCard));
+        Card expectedCard = new CardBuilder(CARD_1).withHint().build();
+        assertParseSuccess(parser, QUESTION_DESC_SAMPLE_1 + ANSWER_DESC_SAMPLE_1, new AddCommand(expectedCard));
     }
 
     @Test
@@ -65,10 +65,10 @@ public class AddCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
         // missing name prefix
-        assertParseFailure(parser, VALID_QUESTION_2 + ANSWER_DESC_BOB, expectedMessage);
+        assertParseFailure(parser, VALID_QUESTION_2 + ANSWER_DESC_SAMPLE_2, expectedMessage);
 
         // missing answer prefix
-        assertParseFailure(parser, QUESTION_DESC_BOB + VALID_ANSWER_2, expectedMessage);
+        assertParseFailure(parser, QUESTION_DESC_SAMPLE_2 + VALID_ANSWER_2, expectedMessage);
 
         // all prefixes missing
         assertParseFailure(parser, VALID_QUESTION_2 + VALID_ANSWER_2, expectedMessage);
@@ -77,22 +77,22 @@ public class AddCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
-        assertParseFailure(parser, INVALID_QUESTION_DESC + ANSWER_DESC_BOB + HINT_DESC_HUSBAND
+        assertParseFailure(parser, INVALID_QUESTION_DESC + ANSWER_DESC_SAMPLE_2 + HINT_DESC_HUSBAND
                 + HINT_DESC_FRIEND, Question.MESSAGE_CONSTRAINTS);
 
         // invalid answer
-        assertParseFailure(parser, QUESTION_DESC_BOB + INVALID_ANSWER_DESC + HINT_DESC_HUSBAND
+        assertParseFailure(parser, QUESTION_DESC_SAMPLE_2 + INVALID_ANSWER_DESC + HINT_DESC_HUSBAND
                 + HINT_DESC_FRIEND, Answer.MESSAGE_CONSTRAINTS);
 
         // invalid hint
-        assertParseFailure(parser, QUESTION_DESC_BOB + ANSWER_DESC_BOB + INVALID_HINT_DESC
+        assertParseFailure(parser, QUESTION_DESC_SAMPLE_2 + ANSWER_DESC_SAMPLE_2 + INVALID_HINT_DESC
                 + VALID_HINT_FRIEND, Hint.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_QUESTION_DESC + ANSWER_DESC_BOB, Question.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INVALID_QUESTION_DESC + ANSWER_DESC_SAMPLE_2, Question.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + QUESTION_DESC_BOB + ANSWER_DESC_BOB
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + QUESTION_DESC_SAMPLE_2 + ANSWER_DESC_SAMPLE_2
                 + HINT_DESC_HUSBAND + HINT_DESC_FRIEND,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -12,9 +12,9 @@ import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_2;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalCards.AMY;
@@ -65,13 +65,13 @@ public class AddCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
         // missing name prefix
-        assertParseFailure(parser, VALID_QUESTION_BOB + ANSWER_DESC_BOB, expectedMessage);
+        assertParseFailure(parser, VALID_QUESTION_2 + ANSWER_DESC_BOB, expectedMessage);
 
         // missing answer prefix
-        assertParseFailure(parser, QUESTION_DESC_BOB + VALID_ANSWER_BOB, expectedMessage);
+        assertParseFailure(parser, QUESTION_DESC_BOB + VALID_ANSWER_2, expectedMessage);
 
         // all prefixes missing
-        assertParseFailure(parser, VALID_QUESTION_BOB + VALID_ANSWER_BOB, expectedMessage);
+        assertParseFailure(parser, VALID_QUESTION_2 + VALID_ANSWER_2, expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -78,7 +78,8 @@ public class EditCommandParserTest {
 
         // while parsing {@code PREFIX_HINT} alone will reset the hints of the {@code Card} being edited,
         // parsing valid hint followed by invalid hint will result in error
-        assertParseFailure(parser, "1" + HINT_DESC_FRIEND + HINT_DESC_HUSBAND + HINT_EMPTY, Hint.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + HINT_DESC_FRIEND + HINT_DESC_HUSBAND + HINT_EMPTY,
+                Hint.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser,
@@ -89,7 +90,8 @@ public class EditCommandParserTest {
     @Test
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_CARD;
-        String userInput = targetIndex.getOneBased() + ANSWER_DESC_SAMPLE_2 + HINT_DESC_HUSBAND + QUESTION_DESC_SAMPLE_1;
+        String userInput = targetIndex.getOneBased() + ANSWER_DESC_SAMPLE_2 + HINT_DESC_HUSBAND
+                + QUESTION_DESC_SAMPLE_1;
 
         EditCommand.EditCardDescriptor descriptor = new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_1)
                 .withAnswer(VALID_ANSWER_2).withHint(VALID_HINT_HUSBAND).build();

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -9,11 +9,11 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_ANSWER_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_HINT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_QUESTION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_1;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_1;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HINT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -42,7 +42,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, VALID_QUESTION_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, VALID_QUESTION_1, MESSAGE_INVALID_FORMAT);
 
         // no field specified
         assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
@@ -82,7 +82,7 @@ public class EditCommandParserTest {
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser,
-                "1" + INVALID_QUESTION_DESC + INVALID_HINT_DESC + VALID_ANSWER_AMY,
+                "1" + INVALID_QUESTION_DESC + INVALID_HINT_DESC + VALID_ANSWER_1,
                 Question.MESSAGE_CONSTRAINTS);
     }
 
@@ -91,8 +91,8 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_SECOND_CARD;
         String userInput = targetIndex.getOneBased() + ANSWER_DESC_BOB + HINT_DESC_HUSBAND + QUESTION_DESC_AMY;
 
-        EditCommand.EditCardDescriptor descriptor = new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_AMY)
-                .withAnswer(VALID_ANSWER_BOB).withHint(VALID_HINT_HUSBAND).build();
+        EditCommand.EditCardDescriptor descriptor = new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_1)
+                .withAnswer(VALID_ANSWER_2).withHint(VALID_HINT_HUSBAND).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -103,7 +103,7 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_FIRST_CARD;
         String userInput = targetIndex.getOneBased() + ANSWER_DESC_BOB;
 
-        EditCommand.EditCardDescriptor descriptor = new EditCardDescriptorBuilder().withAnswer(VALID_ANSWER_BOB)
+        EditCommand.EditCardDescriptor descriptor = new EditCardDescriptorBuilder().withAnswer(VALID_ANSWER_2)
                 .build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
@@ -116,13 +116,13 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_CARD;
         String userInput = targetIndex.getOneBased() + QUESTION_DESC_AMY;
         EditCommand.EditCardDescriptor descriptor =
-                new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_AMY).build();
+                new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_1).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // answer
         userInput = targetIndex.getOneBased() + ANSWER_DESC_AMY;
-        descriptor = new EditCardDescriptorBuilder().withAnswer(VALID_ANSWER_AMY).build();
+        descriptor = new EditCardDescriptorBuilder().withAnswer(VALID_ANSWER_1).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
@@ -139,7 +139,7 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + ANSWER_DESC_AMY + HINT_DESC_FRIEND + ANSWER_DESC_AMY
                 + HINT_DESC_FRIEND + ANSWER_DESC_BOB + HINT_DESC_HUSBAND;
 
-        EditCommand.EditCardDescriptor descriptor = new EditCardDescriptorBuilder().withAnswer(VALID_ANSWER_BOB)
+        EditCommand.EditCardDescriptor descriptor = new EditCardDescriptorBuilder().withAnswer(VALID_ANSWER_2)
                 .withHint(VALID_HINT_HUSBAND).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
@@ -152,13 +152,13 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_FIRST_CARD;
         String userInput = targetIndex.getOneBased() + INVALID_ANSWER_DESC + ANSWER_DESC_BOB;
         EditCommand.EditCardDescriptor descriptor =
-                new EditCardDescriptorBuilder().withAnswer(VALID_ANSWER_BOB).build();
+                new EditCardDescriptorBuilder().withAnswer(VALID_ANSWER_2).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // other valid values specified
         userInput = targetIndex.getOneBased() + INVALID_ANSWER_DESC + ANSWER_DESC_BOB;
-        descriptor = new EditCardDescriptorBuilder().withAnswer(VALID_ANSWER_BOB).build();
+        descriptor = new EditCardDescriptorBuilder().withAnswer(VALID_ANSWER_2).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -1,14 +1,14 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_SAMPLE_1;
+import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_SAMPLE_2;
 import static seedu.address.logic.commands.CommandTestUtil.HINT_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.HINT_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ANSWER_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_HINT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_QUESTION_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_SAMPLE_1;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_1;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_FRIEND;
@@ -54,10 +54,10 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + QUESTION_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5" + QUESTION_DESC_SAMPLE_1, MESSAGE_INVALID_FORMAT);
 
         // zero index
-        assertParseFailure(parser, "0" + QUESTION_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + QUESTION_DESC_SAMPLE_1, MESSAGE_INVALID_FORMAT);
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
@@ -74,7 +74,7 @@ public class EditCommandParserTest {
 
         // valid answer followed by invalid answer. The test case for invalid answer followed by valid answer
         // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
-        assertParseFailure(parser, "1" + ANSWER_DESC_BOB + INVALID_ANSWER_DESC, Answer.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + ANSWER_DESC_SAMPLE_2 + INVALID_ANSWER_DESC, Answer.MESSAGE_CONSTRAINTS);
 
         // while parsing {@code PREFIX_HINT} alone will reset the hints of the {@code Card} being edited,
         // parsing valid hint followed by invalid hint will result in error
@@ -89,7 +89,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_CARD;
-        String userInput = targetIndex.getOneBased() + ANSWER_DESC_BOB + HINT_DESC_HUSBAND + QUESTION_DESC_AMY;
+        String userInput = targetIndex.getOneBased() + ANSWER_DESC_SAMPLE_2 + HINT_DESC_HUSBAND + QUESTION_DESC_SAMPLE_1;
 
         EditCommand.EditCardDescriptor descriptor = new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_1)
                 .withAnswer(VALID_ANSWER_2).withHint(VALID_HINT_HUSBAND).build();
@@ -101,7 +101,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_someFieldsSpecified_success() {
         Index targetIndex = INDEX_FIRST_CARD;
-        String userInput = targetIndex.getOneBased() + ANSWER_DESC_BOB;
+        String userInput = targetIndex.getOneBased() + ANSWER_DESC_SAMPLE_2;
 
         EditCommand.EditCardDescriptor descriptor = new EditCardDescriptorBuilder().withAnswer(VALID_ANSWER_2)
                 .build();
@@ -114,14 +114,14 @@ public class EditCommandParserTest {
     public void parse_oneFieldSpecified_success() {
         // name
         Index targetIndex = INDEX_THIRD_CARD;
-        String userInput = targetIndex.getOneBased() + QUESTION_DESC_AMY;
+        String userInput = targetIndex.getOneBased() + QUESTION_DESC_SAMPLE_1;
         EditCommand.EditCardDescriptor descriptor =
                 new EditCardDescriptorBuilder().withQuestion(VALID_QUESTION_1).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // answer
-        userInput = targetIndex.getOneBased() + ANSWER_DESC_AMY;
+        userInput = targetIndex.getOneBased() + ANSWER_DESC_SAMPLE_1;
         descriptor = new EditCardDescriptorBuilder().withAnswer(VALID_ANSWER_1).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -136,8 +136,8 @@ public class EditCommandParserTest {
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
         Index targetIndex = INDEX_FIRST_CARD;
-        String userInput = targetIndex.getOneBased() + ANSWER_DESC_AMY + HINT_DESC_FRIEND + ANSWER_DESC_AMY
-                + HINT_DESC_FRIEND + ANSWER_DESC_BOB + HINT_DESC_HUSBAND;
+        String userInput = targetIndex.getOneBased() + ANSWER_DESC_SAMPLE_1 + HINT_DESC_FRIEND + ANSWER_DESC_SAMPLE_1
+                + HINT_DESC_FRIEND + ANSWER_DESC_SAMPLE_2 + HINT_DESC_HUSBAND;
 
         EditCommand.EditCardDescriptor descriptor = new EditCardDescriptorBuilder().withAnswer(VALID_ANSWER_2)
                 .withHint(VALID_HINT_HUSBAND).build();
@@ -150,14 +150,14 @@ public class EditCommandParserTest {
     public void parse_invalidValueFollowedByValidValue_success() {
         // no other valid values specified
         Index targetIndex = INDEX_FIRST_CARD;
-        String userInput = targetIndex.getOneBased() + INVALID_ANSWER_DESC + ANSWER_DESC_BOB;
+        String userInput = targetIndex.getOneBased() + INVALID_ANSWER_DESC + ANSWER_DESC_SAMPLE_2;
         EditCommand.EditCardDescriptor descriptor =
                 new EditCardDescriptorBuilder().withAnswer(VALID_ANSWER_2).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // other valid values specified
-        userInput = targetIndex.getOneBased() + INVALID_ANSWER_DESC + ANSWER_DESC_BOB;
+        userInput = targetIndex.getOneBased() + INVALID_ANSWER_DESC + ANSWER_DESC_SAMPLE_2;
         descriptor = new EditCardDescriptorBuilder().withAnswer(VALID_ANSWER_2).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -149,6 +149,20 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void setCurrentTestedCard_cardNotInFilteredCardList_throwsCardNotFoundException() {
+        thrown.expect(CardNotFoundException.class);
+        modelManager.setSelectedCard(ALICE);
+    }
+
+    @Test
+    public void setCurrentTestedCard_cardInFilteredCardList_setsSelectedCard() {
+        modelManager.addCard(ALICE);
+        assertEquals(Collections.singletonList(ALICE), modelManager.getFilteredCards());
+        modelManager.setCurrentTestedCard(ALICE);
+        assertEquals(ALICE, modelManager.getCurrentTestedCard());
+    }
+
+    @Test
     public void equals() {
         CardFolder cardFolder = new CardFolderBuilder().withCard(ALICE).withCard(BENSON).build();
         CardFolder differentCardFolder = new CardFolder(this.getClass().getName());

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -3,7 +3,7 @@ package seedu.address.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CARDS;
 import static seedu.address.testutil.TypicalCards.ALICE;
 import static seedu.address.testutil.TypicalCards.BENSON;
@@ -123,7 +123,7 @@ public class ModelManagerTest {
     public void setCard_cardIsSelected_selectedCardUpdated() {
         modelManager.addCard(ALICE);
         modelManager.setSelectedCard(ALICE);
-        Card updatedAlice = new CardBuilder(ALICE).withAnswer(VALID_ANSWER_BOB).build();
+        Card updatedAlice = new CardBuilder(ALICE).withAnswer(VALID_ANSWER_2).build();
         modelManager.setCard(ALICE, updatedAlice);
         assertEquals(updatedAlice, modelManager.getSelectedCard());
     }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -7,7 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CARDS;
 import static seedu.address.testutil.TypicalCards.ALICE;
 import static seedu.address.testutil.TypicalCards.BENSON;
-import static seedu.address.testutil.TypicalCards.BOB;
+import static seedu.address.testutil.TypicalCards.CARD_2;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -112,10 +112,10 @@ public class ModelManagerTest {
     @Test
     public void deleteCard_cardIsSelectedAndSecondCardInFilteredCardList_firstCardSelected() {
         modelManager.addCard(ALICE);
-        modelManager.addCard(BOB);
-        assertEquals(Arrays.asList(ALICE, BOB), modelManager.getFilteredCards());
-        modelManager.setSelectedCard(BOB);
-        modelManager.deleteCard(BOB);
+        modelManager.addCard(CARD_2);
+        assertEquals(Arrays.asList(ALICE, CARD_2), modelManager.getFilteredCards());
+        modelManager.setSelectedCard(CARD_2);
+        modelManager.deleteCard(CARD_2);
         assertEquals(ALICE, modelManager.getSelectedCard());
     }
 

--- a/src/test/java/seedu/address/model/VersionedCardFolderTest.java
+++ b/src/test/java/seedu/address/model/VersionedCardFolderTest.java
@@ -4,8 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static seedu.address.testutil.TypicalCards.AMY;
-import static seedu.address.testutil.TypicalCards.BOB;
+import static seedu.address.testutil.TypicalCards.CARD_1;
+import static seedu.address.testutil.TypicalCards.CARD_2;
 import static seedu.address.testutil.TypicalCards.CARL;
 
 import java.util.Arrays;
@@ -18,8 +18,8 @@ import seedu.address.testutil.CardFolderBuilder;
 
 public class VersionedCardFolderTest {
 
-    private final ReadOnlyCardFolder cardFolderWithAmy = new CardFolderBuilder().withCard(AMY).build();
-    private final ReadOnlyCardFolder cardFolderWithBob = new CardFolderBuilder().withCard(BOB).build();
+    private final ReadOnlyCardFolder cardFolderWithAmy = new CardFolderBuilder().withCard(CARD_1).build();
+    private final ReadOnlyCardFolder cardFolderWithBob = new CardFolderBuilder().withCard(CARD_2).build();
     private final ReadOnlyCardFolder cardFolderWithCarl = new CardFolderBuilder().withCard(CARL).build();
     private final ReadOnlyCardFolder emptyCardFolder = new CardFolderBuilder().build();
 

--- a/src/test/java/seedu/address/model/card/CardTest.java
+++ b/src/test/java/seedu/address/model/card/CardTest.java
@@ -2,9 +2,9 @@ package seedu.address.model.card;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_2;
 import static seedu.address.testutil.TypicalCards.ALICE;
 import static seedu.address.testutil.TypicalCards.BOB;
 
@@ -34,11 +34,11 @@ public class CardTest {
         assertFalse(ALICE.isSameCard(null));
 
         // different answer -> returns false
-        Card editedAlice = new CardBuilder(ALICE).withAnswer(VALID_ANSWER_BOB).build();
+        Card editedAlice = new CardBuilder(ALICE).withAnswer(VALID_ANSWER_2).build();
         assertFalse(ALICE.isSameCard(editedAlice));
 
         // different question -> returns false
-        editedAlice = new CardBuilder(ALICE).withQuestion(VALID_QUESTION_BOB).build();
+        editedAlice = new CardBuilder(ALICE).withQuestion(VALID_QUESTION_2).build();
         assertFalse(ALICE.isSameCard(editedAlice));
 
         // same question, same answer, different attributes -> returns true
@@ -46,7 +46,7 @@ public class CardTest {
         assertTrue(ALICE.isSameCard(editedAlice));
 
         // same question, different answer, different attributes -> returns false
-        editedAlice = new CardBuilder(ALICE).withAnswer(VALID_ANSWER_BOB).withHint(VALID_HINT_HUSBAND).build();
+        editedAlice = new CardBuilder(ALICE).withAnswer(VALID_ANSWER_2).withHint(VALID_HINT_HUSBAND).build();
         assertFalse(ALICE.isSameCard(editedAlice));
 
         // same question, same answer, different attributes -> returns true
@@ -73,11 +73,11 @@ public class CardTest {
         assertFalse(ALICE.equals(BOB));
 
         // different question -> returns false
-        Card editedAlice = new CardBuilder(ALICE).withQuestion(VALID_QUESTION_BOB).build();
+        Card editedAlice = new CardBuilder(ALICE).withQuestion(VALID_QUESTION_2).build();
         assertFalse(ALICE.equals(editedAlice));
 
         // different answer -> returns false
-        editedAlice = new CardBuilder(ALICE).withAnswer(VALID_ANSWER_BOB).build();
+        editedAlice = new CardBuilder(ALICE).withAnswer(VALID_ANSWER_2).build();
         assertFalse(ALICE.equals(editedAlice));
 
         // different hint -> returns false

--- a/src/test/java/seedu/address/model/card/CardTest.java
+++ b/src/test/java/seedu/address/model/card/CardTest.java
@@ -6,7 +6,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_2;
 import static seedu.address.testutil.TypicalCards.ALICE;
-import static seedu.address.testutil.TypicalCards.BOB;
+import static seedu.address.testutil.TypicalCards.CARD_2;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -70,7 +70,7 @@ public class CardTest {
         assertFalse(ALICE.equals(5));
 
         // different card -> returns false
-        assertFalse(ALICE.equals(BOB));
+        assertFalse(ALICE.equals(CARD_2));
 
         // different question -> returns false
         Card editedAlice = new CardBuilder(ALICE).withQuestion(VALID_QUESTION_2).build();

--- a/src/test/java/seedu/address/model/card/UniqueCardListTest.java
+++ b/src/test/java/seedu/address/model/card/UniqueCardListTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_HUSBAND;
 import static seedu.address.testutil.TypicalCards.ALICE;
-import static seedu.address.testutil.TypicalCards.BOB;
+import static seedu.address.testutil.TypicalCards.CARD_2;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -104,18 +104,18 @@ public class UniqueCardListTest {
     @Test
     public void setCard_editedCardHasDifferentIdentity_success() {
         uniqueCardList.add(ALICE);
-        uniqueCardList.setCard(ALICE, BOB);
+        uniqueCardList.setCard(ALICE, CARD_2);
         UniqueCardList expectedUniqueCardList = new UniqueCardList();
-        expectedUniqueCardList.add(BOB);
+        expectedUniqueCardList.add(CARD_2);
         assertEquals(expectedUniqueCardList, uniqueCardList);
     }
 
     @Test
     public void setCard_editedCardHasNonUniqueIdentity_throwsDuplicateCardException() {
         uniqueCardList.add(ALICE);
-        uniqueCardList.add(BOB);
+        uniqueCardList.add(CARD_2);
         thrown.expect(DuplicateCardException.class);
-        uniqueCardList.setCard(ALICE, BOB);
+        uniqueCardList.setCard(ALICE, CARD_2);
     }
 
     @Test
@@ -148,7 +148,7 @@ public class UniqueCardListTest {
     public void setCards_uniqueCardList_replacesOwnListWithProvidedUniqueCardList() {
         uniqueCardList.add(ALICE);
         UniqueCardList expectedUniqueCardList = new UniqueCardList();
-        expectedUniqueCardList.add(BOB);
+        expectedUniqueCardList.add(CARD_2);
         uniqueCardList.setCards(expectedUniqueCardList);
         assertEquals(expectedUniqueCardList, uniqueCardList);
     }
@@ -162,10 +162,10 @@ public class UniqueCardListTest {
     @Test
     public void setCards_list_replacesOwnListWithProvidedList() {
         uniqueCardList.add(ALICE);
-        List<Card> cardList = Collections.singletonList(BOB);
+        List<Card> cardList = Collections.singletonList(CARD_2);
         uniqueCardList.setCards(cardList);
         UniqueCardList expectedUniqueCardList = new UniqueCardList();
-        expectedUniqueCardList.add(BOB);
+        expectedUniqueCardList.add(CARD_2);
         assertEquals(expectedUniqueCardList, uniqueCardList);
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalCards.java
+++ b/src/test/java/seedu/address/testutil/TypicalCards.java
@@ -6,7 +6,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_1;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_2;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_SCORE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SCORE_1;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,9 +44,9 @@ public class TypicalCards {
             .build();
 
     // Manually added - Card's details found in {@code CommandTestUtil}
-    public static final Card AMY = new CardBuilder().withQuestion(VALID_QUESTION_1).withAnswer(VALID_ANSWER_1)
-            .withScore(VALID_SCORE_AMY).withHint(VALID_HINT_FRIEND).build();
-    public static final Card BOB = new CardBuilder().withQuestion(VALID_QUESTION_2).withAnswer(VALID_ANSWER_2)
+    public static final Card CARD_1 = new CardBuilder().withQuestion(VALID_QUESTION_1).withAnswer(VALID_ANSWER_1)
+            .withScore(VALID_SCORE_1).withHint(VALID_HINT_FRIEND).build();
+    public static final Card CARD_2 = new CardBuilder().withQuestion(VALID_QUESTION_2).withAnswer(VALID_ANSWER_2)
             .withScore("0/0").withHint(VALID_HINT_HUSBAND).build();
 
     public static final String TYPICAL_FOLDER_NAME = "Typical Cards";

--- a/src/test/java/seedu/address/testutil/TypicalCards.java
+++ b/src/test/java/seedu/address/testutil/TypicalCards.java
@@ -1,11 +1,11 @@
 package seedu.address.testutil;
 
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_1;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_1;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SCORE_AMY;
 
 import java.util.ArrayList;
@@ -44,9 +44,9 @@ public class TypicalCards {
             .build();
 
     // Manually added - Card's details found in {@code CommandTestUtil}
-    public static final Card AMY = new CardBuilder().withQuestion(VALID_QUESTION_AMY).withAnswer(VALID_ANSWER_AMY)
+    public static final Card AMY = new CardBuilder().withQuestion(VALID_QUESTION_1).withAnswer(VALID_ANSWER_1)
             .withScore(VALID_SCORE_AMY).withHint(VALID_HINT_FRIEND).build();
-    public static final Card BOB = new CardBuilder().withQuestion(VALID_QUESTION_BOB).withAnswer(VALID_ANSWER_BOB)
+    public static final Card BOB = new CardBuilder().withQuestion(VALID_QUESTION_2).withAnswer(VALID_ANSWER_2)
             .withScore("0/0").withHint(VALID_HINT_HUSBAND).build();
 
     public static final String TYPICAL_FOLDER_NAME = "Typical Cards";

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -11,4 +11,5 @@ public class TypicalIndexes {
     public static final Index INDEX_THIRD_CARD = Index.fromOneBased(3);
 
     public static final Index INDEX_FIRST_CARD_FOLDER = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_CARD_FOLDER = Index.fromOneBased(2);
 }

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -10,8 +10,8 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_HINT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_QUESTION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_2;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HINT;
 import static seedu.address.testutil.TypicalCards.ALICE;
 import static seedu.address.testutil.TypicalCards.AMY;
@@ -64,12 +64,12 @@ public class AddCommandSystemTest extends CardFolderSystemTest {
         assertCommandSuccess(command, model, expectedResultMessage);
 
         /* Case: add a card with all fields same as another card in the card folder except question -> added */
-        toAdd = new CardBuilder(AMY).withQuestion(VALID_QUESTION_BOB).build();
+        toAdd = new CardBuilder(AMY).withQuestion(VALID_QUESTION_2).build();
         command = AddCommand.COMMAND_WORD + QUESTION_DESC_BOB + ANSWER_DESC_AMY + HINT_DESC_FRIEND;
         assertCommandSuccess(command, toAdd);
 
         /* Case: add a card with all fields same as another card in the card folder except answer -> added */
-        toAdd = new CardBuilder(AMY).withAnswer(VALID_ANSWER_BOB).build();
+        toAdd = new CardBuilder(AMY).withAnswer(VALID_ANSWER_2).build();
         command = CardUtil.getAddCommand(toAdd);
         assertCommandSuccess(command, toAdd);
 

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -1,21 +1,21 @@
 package systemtests;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_SAMPLE_1;
+import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_SAMPLE_2;
 import static seedu.address.logic.commands.CommandTestUtil.HINT_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.HINT_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ANSWER_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_HINT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_QUESTION_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_SAMPLE_1;
+import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_SAMPLE_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_2;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HINT;
 import static seedu.address.testutil.TypicalCards.ALICE;
-import static seedu.address.testutil.TypicalCards.AMY;
-import static seedu.address.testutil.TypicalCards.BOB;
+import static seedu.address.testutil.TypicalCards.CARD_1;
+import static seedu.address.testutil.TypicalCards.CARD_2;
 import static seedu.address.testutil.TypicalCards.CARL;
 import static seedu.address.testutil.TypicalCards.HOON;
 import static seedu.address.testutil.TypicalCards.IDA;
@@ -47,8 +47,8 @@ public class AddCommandSystemTest extends CardFolderSystemTest {
         /* Case: add a card without hints to a non-empty card folder, command with leading spaces and trailing spaces
          * -> added
          */
-        Card toAdd = AMY;
-        String command = "   " + AddCommand.COMMAND_WORD + "  " + QUESTION_DESC_AMY + "  " + ANSWER_DESC_AMY + " "
+        Card toAdd = CARD_1;
+        String command = "   " + AddCommand.COMMAND_WORD + "  " + QUESTION_DESC_SAMPLE_1 + "  " + ANSWER_DESC_SAMPLE_1 + " "
                 + "   " + HINT_DESC_FRIEND + " ";
         assertCommandSuccess(command, toAdd);
 
@@ -64,12 +64,12 @@ public class AddCommandSystemTest extends CardFolderSystemTest {
         assertCommandSuccess(command, model, expectedResultMessage);
 
         /* Case: add a card with all fields same as another card in the card folder except question -> added */
-        toAdd = new CardBuilder(AMY).withQuestion(VALID_QUESTION_2).build();
-        command = AddCommand.COMMAND_WORD + QUESTION_DESC_BOB + ANSWER_DESC_AMY + HINT_DESC_FRIEND;
+        toAdd = new CardBuilder(CARD_1).withQuestion(VALID_QUESTION_2).build();
+        command = AddCommand.COMMAND_WORD + QUESTION_DESC_SAMPLE_2 + ANSWER_DESC_SAMPLE_1 + HINT_DESC_FRIEND;
         assertCommandSuccess(command, toAdd);
 
         /* Case: add a card with all fields same as another card in the card folder except answer -> added */
-        toAdd = new CardBuilder(AMY).withAnswer(VALID_ANSWER_2).build();
+        toAdd = new CardBuilder(CARD_1).withAnswer(VALID_ANSWER_2).build();
         command = CardUtil.getAddCommand(toAdd);
         assertCommandSuccess(command, toAdd);
 
@@ -78,8 +78,8 @@ public class AddCommandSystemTest extends CardFolderSystemTest {
         assertCommandSuccess(ALICE);
 
         /* Case: add a card with hints, command with parameters in random order -> added */
-        toAdd = BOB;
-        command = AddCommand.COMMAND_WORD + HINT_DESC_FRIEND + ANSWER_DESC_BOB + QUESTION_DESC_BOB
+        toAdd = CARD_2;
+        command = AddCommand.COMMAND_WORD + HINT_DESC_FRIEND + ANSWER_DESC_SAMPLE_2 + QUESTION_DESC_SAMPLE_2
                 + HINT_DESC_HUSBAND;
         assertCommandSuccess(command, toAdd);
 
@@ -115,11 +115,11 @@ public class AddCommandSystemTest extends CardFolderSystemTest {
         assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_CARD);
 
         /* Case: missing question -> rejected */
-        command = AddCommand.COMMAND_WORD + ANSWER_DESC_AMY;
+        command = AddCommand.COMMAND_WORD + ANSWER_DESC_SAMPLE_1;
         assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
 
         /* Case: missing answer -> rejected */
-        command = AddCommand.COMMAND_WORD + QUESTION_DESC_AMY;
+        command = AddCommand.COMMAND_WORD + QUESTION_DESC_SAMPLE_1;
         assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
 
         /* Case: invalid keyword -> rejected */
@@ -127,15 +127,15 @@ public class AddCommandSystemTest extends CardFolderSystemTest {
         assertCommandFailure(command, Messages.MESSAGE_UNKNOWN_COMMAND);
 
         /* Case: invalid question -> rejected */
-        command = AddCommand.COMMAND_WORD + INVALID_QUESTION_DESC + ANSWER_DESC_AMY;
+        command = AddCommand.COMMAND_WORD + INVALID_QUESTION_DESC + ANSWER_DESC_SAMPLE_1;
         assertCommandFailure(command, Question.MESSAGE_CONSTRAINTS);
 
         /* Case: invalid answer -> rejected */
-        command = AddCommand.COMMAND_WORD + QUESTION_DESC_AMY + INVALID_ANSWER_DESC;
+        command = AddCommand.COMMAND_WORD + QUESTION_DESC_SAMPLE_1 + INVALID_ANSWER_DESC;
         assertCommandFailure(command, Answer.MESSAGE_CONSTRAINTS);
 
         /* Case: invalid hint -> rejected */
-        command = AddCommand.COMMAND_WORD + QUESTION_DESC_AMY + ANSWER_DESC_AMY
+        command = AddCommand.COMMAND_WORD + QUESTION_DESC_SAMPLE_1 + ANSWER_DESC_SAMPLE_1
                 + INVALID_HINT_DESC;
         assertCommandFailure(command, Hint.MESSAGE_CONSTRAINTS);
     }

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -48,8 +48,8 @@ public class AddCommandSystemTest extends CardFolderSystemTest {
          * -> added
          */
         Card toAdd = CARD_1;
-        String command = "   " + AddCommand.COMMAND_WORD + "  " + QUESTION_DESC_SAMPLE_1 + "  " + ANSWER_DESC_SAMPLE_1 + " "
-                + "   " + HINT_DESC_FRIEND + " ";
+        String command = "   " + AddCommand.COMMAND_WORD + "  " + QUESTION_DESC_SAMPLE_1 + "  " + ANSWER_DESC_SAMPLE_1
+                + " " + "   " + HINT_DESC_FRIEND + " ";
         assertCommandSuccess(command, toAdd);
 
         /* Case: undo adding Amy to the list -> Amy deleted */

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -12,10 +12,10 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_HINT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_QUESTION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_1;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_1;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_2;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HINT;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CARDS;
 import static seedu.address.testutil.TypicalCards.AMY;
@@ -80,7 +80,7 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
         command =
                 EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_AMY + ANSWER_DESC_BOB
                        + HINT_DESC_FRIEND + HINT_DESC_HUSBAND;
-        editedCard = new CardBuilder(BOB).withQuestion(VALID_QUESTION_AMY).build();
+        editedCard = new CardBuilder(BOB).withQuestion(VALID_QUESTION_1).build();
         assertCommandSuccess(command, index, editedCard);
 
         /* Case: edit a card with new values same as another card's values but with different answer -> edited */
@@ -88,7 +88,7 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
         command =
                 EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_BOB + ANSWER_DESC_AMY
                         + HINT_DESC_FRIEND + HINT_DESC_HUSBAND;
-        editedCard = new CardBuilder(BOB).withAnswer(VALID_ANSWER_AMY).build();
+        editedCard = new CardBuilder(BOB).withAnswer(VALID_ANSWER_1).build();
         assertCommandSuccess(command, index, editedCard);
 
         /* Case: clear hints -> cleared */
@@ -106,7 +106,7 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
         assertTrue(index.getZeroBased() < getModel().getFilteredCards().size());
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + " " + QUESTION_DESC_BOB;
         cardToEdit = getModel().getFilteredCards().get(index.getZeroBased());
-        editedCard = new CardBuilder(cardToEdit).withQuestion(VALID_QUESTION_BOB).build();
+        editedCard = new CardBuilder(cardToEdit).withQuestion(VALID_QUESTION_2).build();
         assertCommandSuccess(command, index, editedCard);
 
         /* Case: filtered card list, edit index within bounds of card folder but out of bounds of card list

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -3,23 +3,23 @@ package systemtests;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_SAMPLE_1;
+import static seedu.address.logic.commands.CommandTestUtil.ANSWER_DESC_SAMPLE_2;
 import static seedu.address.logic.commands.CommandTestUtil.HINT_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.HINT_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ANSWER_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_HINT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_QUESTION_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_SAMPLE_1;
+import static seedu.address.logic.commands.CommandTestUtil.QUESTION_DESC_SAMPLE_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_1;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_HINT_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_1;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_QUESTION_2;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_HINT;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CARDS;
-import static seedu.address.testutil.TypicalCards.AMY;
-import static seedu.address.testutil.TypicalCards.BOB;
+import static seedu.address.testutil.TypicalCards.CARD_1;
+import static seedu.address.testutil.TypicalCards.CARD_2;
 import static seedu.address.testutil.TypicalCards.KEYWORD_MATCHING_MEIER;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CARD;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CARD;
@@ -51,9 +51,9 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
          * -> edited
          */
         Index index = INDEX_FIRST_CARD;
-        String command = " " + EditCommand.COMMAND_WORD + "  " + index.getOneBased() + "  " + QUESTION_DESC_BOB + "  "
-                + ANSWER_DESC_BOB + " " + HINT_DESC_HUSBAND + " ";
-        Card editedCard = new CardBuilder(BOB).withHint(VALID_HINT_HUSBAND).build();
+        String command = " " + EditCommand.COMMAND_WORD + "  " + index.getOneBased() + "  " + QUESTION_DESC_SAMPLE_2 + "  "
+                + ANSWER_DESC_SAMPLE_2 + " " + HINT_DESC_HUSBAND + " ";
+        Card editedCard = new CardBuilder(CARD_2).withHint(VALID_HINT_HUSBAND).build();
         assertCommandSuccess(command, index, editedCard);
 
         /* Case: undo editing the last card in the list -> last card restored */
@@ -69,26 +69,26 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
 
         /* Case: edit a card with new values same as existing values -> edited */
         command =
-                EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_BOB + ANSWER_DESC_BOB
+                EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_SAMPLE_2 + ANSWER_DESC_SAMPLE_2
                        + HINT_DESC_FRIEND + HINT_DESC_HUSBAND;
-        assertCommandSuccess(command, index, BOB);
+        assertCommandSuccess(command, index, CARD_2);
 
         /* Case: edit a card with new values same as another card's values but with different question -> edited */
-        assertTrue(getModel().getActiveCardFolder().getCardList().contains(BOB));
+        assertTrue(getModel().getActiveCardFolder().getCardList().contains(CARD_2));
         index = INDEX_SECOND_CARD;
-        assertNotEquals(getModel().getFilteredCards().get(index.getZeroBased()), BOB);
+        assertNotEquals(getModel().getFilteredCards().get(index.getZeroBased()), CARD_2);
         command =
-                EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_AMY + ANSWER_DESC_BOB
+                EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_SAMPLE_1 + ANSWER_DESC_SAMPLE_2
                        + HINT_DESC_FRIEND + HINT_DESC_HUSBAND;
-        editedCard = new CardBuilder(BOB).withQuestion(VALID_QUESTION_1).build();
+        editedCard = new CardBuilder(CARD_2).withQuestion(VALID_QUESTION_1).build();
         assertCommandSuccess(command, index, editedCard);
 
         /* Case: edit a card with new values same as another card's values but with different answer -> edited */
         index = INDEX_SECOND_CARD;
         command =
-                EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_BOB + ANSWER_DESC_AMY
+                EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_SAMPLE_2 + ANSWER_DESC_SAMPLE_1
                         + HINT_DESC_FRIEND + HINT_DESC_HUSBAND;
-        editedCard = new CardBuilder(BOB).withAnswer(VALID_ANSWER_1).build();
+        editedCard = new CardBuilder(CARD_2).withAnswer(VALID_ANSWER_1).build();
         assertCommandSuccess(command, index, editedCard);
 
         /* Case: clear hints -> cleared */
@@ -104,7 +104,7 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
         showCardsWithQuestion(KEYWORD_MATCHING_MEIER);
         index = INDEX_FIRST_CARD;
         assertTrue(index.getZeroBased() < getModel().getFilteredCards().size());
-        command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + " " + QUESTION_DESC_BOB;
+        command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + " " + QUESTION_DESC_SAMPLE_2;
         cardToEdit = getModel().getFilteredCards().get(index.getZeroBased());
         editedCard = new CardBuilder(cardToEdit).withQuestion(VALID_QUESTION_2).build();
         assertCommandSuccess(command, index, editedCard);
@@ -114,7 +114,7 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
          */
         showCardsWithQuestion(KEYWORD_MATCHING_MEIER);
         int invalidIndex = getModel().getActiveCardFolder().getCardList().size();
-        assertCommandFailure(EditCommand.COMMAND_WORD + " " + invalidIndex + QUESTION_DESC_BOB,
+        assertCommandFailure(EditCommand.COMMAND_WORD + " " + invalidIndex + QUESTION_DESC_SAMPLE_2,
                 Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
 
         /* --------------------- Performing edit operation while a card card is selected -------------------------- */
@@ -126,29 +126,29 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
         index = INDEX_FIRST_CARD;
         selectCard(index);
         command =
-                EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_AMY + ANSWER_DESC_AMY
+                EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_SAMPLE_1 + ANSWER_DESC_SAMPLE_1
                        + HINT_DESC_FRIEND;
         // this can be misleading: card selection actually remains unchanged but the
         // browser's url is updated to reflect the new card's question
-        assertCommandSuccess(command, index, AMY, index);
+        assertCommandSuccess(command, index, CARD_1, index);
 
         /* --------------------------------- Performing invalid edit operation -------------------------------------- */
 
         /* Case: invalid index (0) -> rejected */
-        assertCommandFailure(EditCommand.COMMAND_WORD + " 0" + QUESTION_DESC_BOB,
+        assertCommandFailure(EditCommand.COMMAND_WORD + " 0" + QUESTION_DESC_SAMPLE_2,
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
 
         /* Case: invalid index (-1) -> rejected */
-        assertCommandFailure(EditCommand.COMMAND_WORD + " -1" + QUESTION_DESC_BOB,
+        assertCommandFailure(EditCommand.COMMAND_WORD + " -1" + QUESTION_DESC_SAMPLE_2,
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
 
         /* Case: invalid index (size + 1) -> rejected */
         invalidIndex = getModel().getFilteredCards().size() + 1;
-        assertCommandFailure(EditCommand.COMMAND_WORD + " " + invalidIndex + QUESTION_DESC_BOB,
+        assertCommandFailure(EditCommand.COMMAND_WORD + " " + invalidIndex + QUESTION_DESC_SAMPLE_2,
                 Messages.MESSAGE_INVALID_CARD_DISPLAYED_INDEX);
 
         /* Case: missing index -> rejected */
-        assertCommandFailure(EditCommand.COMMAND_WORD + QUESTION_DESC_BOB,
+        assertCommandFailure(EditCommand.COMMAND_WORD + QUESTION_DESC_SAMPLE_2,
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
 
         /* Case: missing all fields -> rejected */
@@ -168,24 +168,24 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
                 + INVALID_HINT_DESC, Hint.MESSAGE_CONSTRAINTS);
 
         /* Case: edit a card with new values same as another card's values -> rejected */
-        executeCommand(CardUtil.getAddCommand(BOB));
-        assertTrue(getModel().getActiveCardFolder().getCardList().contains(BOB));
+        executeCommand(CardUtil.getAddCommand(CARD_2));
+        assertTrue(getModel().getActiveCardFolder().getCardList().contains(CARD_2));
         index = INDEX_FIRST_CARD;
-        assertFalse(getModel().getFilteredCards().get(index.getZeroBased()).equals(BOB));
+        assertFalse(getModel().getFilteredCards().get(index.getZeroBased()).equals(CARD_2));
         command =
-                EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_BOB + ANSWER_DESC_BOB
+                EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_SAMPLE_2 + ANSWER_DESC_SAMPLE_2
                        + HINT_DESC_FRIEND + HINT_DESC_HUSBAND;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_CARD);
 
         /* Case: edit a card with new values same as another card's values but with different hints -> rejected */
         command =
-                EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_BOB + ANSWER_DESC_BOB
+                EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_SAMPLE_2 + ANSWER_DESC_SAMPLE_2
                        + HINT_DESC_HUSBAND;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_CARD);
 
         /* Case: edit a card with new values same as another card's values but with different answer -> rejected */
         command =
-                EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_BOB + ANSWER_DESC_AMY
+                EditCommand.COMMAND_WORD + " " + index.getOneBased() + QUESTION_DESC_SAMPLE_2 + ANSWER_DESC_SAMPLE_1
                        + HINT_DESC_FRIEND + HINT_DESC_HUSBAND;
         assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_CARD);
     }

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -51,8 +51,8 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
          * -> edited
          */
         Index index = INDEX_FIRST_CARD;
-        String command = " " + EditCommand.COMMAND_WORD + "  " + index.getOneBased() + "  " + QUESTION_DESC_SAMPLE_2 + "  "
-                + ANSWER_DESC_SAMPLE_2 + " " + HINT_DESC_HUSBAND + " ";
+        String command = " " + EditCommand.COMMAND_WORD + "  " + index.getOneBased() + "  " + QUESTION_DESC_SAMPLE_2
+                + "  " + ANSWER_DESC_SAMPLE_2 + " " + HINT_DESC_HUSBAND + " ";
         Card editedCard = new CardBuilder(CARD_2).withHint(VALID_HINT_HUSBAND).build();
         assertCommandSuccess(command, index, editedCard);
 


### PR DESCRIPTION
- Refactor some default examples in comandTestUtil
- Test Command hardcoded functionality replaced with using ActiveFolderIndex, so test command internally enters the folder (to update again once enter folder functionality is implemented)
- Integration and junit tests for test, end and answer commands

To do: 
- End Command to internally exit the folder (to implement once exit folder functionality is implemented)
- To add GUI tests and systems tests in the future
