### PR TITLE
Add sorting

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -128,7 +128,7 @@ Format: `end`
 
 === Sort cards by level within a folder : `sort`
 
-Displays all flashcards sorted such that the lowest user performing cards are at the top temporarily. +
+Displays all flashcards sorted such that the lowest scoring cards are at the top temporarily. +
 Format: `sort`
 
 === Search by keywords : `search`

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -72,7 +72,7 @@ public class EditCommand extends Command {
         Card cardToEdit = lastShownList.get(index.getZeroBased());
         Card editedCard = createEditedCard(cardToEdit, editCardDescriptor);
 
-        if (!cardToEdit.isSameCard(editedCard) && model.hasCard(editedCard)) {
+        if (!cardToEdit.equals(editedCard) && model.hasCard(editedCard)) {
             throw new CommandException(MESSAGE_DUPLICATE_CARD);
         }
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.COMPARATOR_LEXICOGRAPHIC_CARDS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CARDS;
 
 import seedu.address.logic.CommandHistory;
@@ -19,6 +20,7 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
+        model.sortFilteredCard(COMPARATOR_LEXICOGRAPHIC_CARDS);
         model.updateFilteredCard(PREDICATE_SHOW_ALL_CARDS);
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.COMPARATOR_DESCENDING_CARDS;
+
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -9,10 +12,15 @@ import seedu.address.model.Model;
  * highest.
  */
 public class SortCommand extends Command {
-    public static final String COMMAND_USAGE = "sort";
-    public static final String MESSAGE_SUCCESS = "Sorted flashcards";
+
+    public static final String COMMAND_WORD = "sort";
+
+    public static final String MESSAGE_SUCCESS = "Sorted flashcards with lowest score first";
+
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
-        return null;
+        requireNonNull(model);
+        model.sortFilteredCard(COMPARATOR_DESCENDING_CARDS);
+        return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.COMPARATOR_DESCENDING_CARDS;
+import static seedu.address.model.Model.COMPARATOR_ASC_SCORE_CARDS;
 
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -20,7 +20,7 @@ public class SortCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
-        model.sortFilteredCard(COMPARATOR_DESCENDING_CARDS);
+        model.sortFilteredCard(COMPARATOR_ASC_SCORE_CARDS);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/CommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CommandParser.java
@@ -25,6 +25,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SearchCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.TestCommand;
 import seedu.address.logic.commands.UndoCommand;
 
@@ -98,6 +99,9 @@ public class CommandParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case SortCommand.COMMAND_WORD:
+            return new SortCommand();
 
         case HistoryCommand.COMMAND_WORD:
             return new HistoryCommand();

--- a/src/main/java/seedu/address/model/CardFolder.java
+++ b/src/main/java/seedu/address/model/CardFolder.java
@@ -13,7 +13,7 @@ import seedu.address.model.card.UniqueCardList;
 
 /**
  * Wraps all data at the address-book level
- * Duplicates are not allowed (by .isSameCard comparison)
+ * Duplicates are not allowed (by .equals comparison)
  */
 public class CardFolder implements ReadOnlyCardFolder {
 

--- a/src/main/java/seedu/address/model/CardFolder.java
+++ b/src/main/java/seedu/address/model/CardFolder.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Comparator;
 import java.util.List;
 
 import javafx.beans.InvalidationListener;
@@ -131,6 +132,10 @@ public class CardFolder implements ReadOnlyCardFolder {
     @Override
     public ObservableList<Card> getCardList() {
         return cards.asUnmodifiableObservableList();
+    }
+
+    public void sortCards(Comparator<Card> comparator) {
+        cards.sortCards(comparator);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -20,7 +20,10 @@ import seedu.address.storage.csvmanager.CardFolderExport;
 public interface Model extends Observable {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Card> PREDICATE_SHOW_ALL_CARDS = unused -> true;
-    Comparator<Card> COMPARATOR_DESCENDING_CARDS = (card1, card2) -> -1*card1.getScore().compareTo(card2.getScore());
+    /** {@code Comparator} that sorts cards by ascending percentage score */
+    Comparator<Card> COMPARATOR_ASC_SCORE_CARDS = Comparator.comparing(Card::getScore);
+    /** {@code Comparator} that sorts cards by ascending percentage score */
+    Comparator<Card> COMPARATOR_LEXICOGRAPHIC_CARDS = Comparator.comparing(Card::getQuestion);
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -22,7 +22,7 @@ public interface Model extends Observable {
     Predicate<Card> PREDICATE_SHOW_ALL_CARDS = unused -> true;
     /** {@code Comparator} that sorts cards by ascending percentage score */
     Comparator<Card> COMPARATOR_ASC_SCORE_CARDS = Comparator.comparing(Card::getScore);
-    /** {@code Comparator} that sorts cards by ascending percentage score */
+    /** {@code Comparator} that sorts cards by lexicographic order of questions */
     Comparator<Card> COMPARATOR_LEXICOGRAPHIC_CARDS = Comparator.comparing(Card::getQuestion);
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -19,6 +20,7 @@ import seedu.address.storage.csvmanager.CardFolderExport;
 public interface Model extends Observable {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Card> PREDICATE_SHOW_ALL_CARDS = unused -> true;
+    Comparator<Card> COMPARATOR_DESCENDING_CARDS = (card1, card2) -> -1*card1.getScore().compareTo(card2.getScore());
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -122,6 +124,12 @@ public interface Model extends Observable {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredCard(Predicate<Card> predicate);
+
+    /**
+     * Updates the filter of the filtered card list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void sortFilteredCard(Comparator<Card> cardComparator);
 
     /**
      * Returns true if the model has previous card folder states to restore.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -38,7 +39,7 @@ public class ModelManager implements Model {
     private int activeCardFolderIndex;
     private boolean inFolder;
     private final UserPrefs userPrefs;
-    private final List<FilteredList<Card>> filteredCardsList;
+    private final List<ObservableList<Card>> filteredCardsList;
     private final SimpleObjectProperty<Card> selectedCard = new SimpleObjectProperty<>();
     private final SimpleObjectProperty<Card> currentTestedCard = new SimpleObjectProperty<>();
     private boolean insideTestSession = false;
@@ -64,7 +65,7 @@ public class ModelManager implements Model {
 
         filteredCardsList = new ArrayList<>();
         for (int i = 0; i < filteredFoldersList.size(); i++) {
-            FilteredList<Card> filteredCards = new FilteredList<>(filteredFoldersList.get(i).getCardList());
+            ObservableList<Card> filteredCards = new FilteredList<>(filteredFoldersList.get(i).getCardList());
             filteredCardsList.add(filteredCards);
             filteredCards.addListener(this::ensureSelectedCardIsValid);
         }
@@ -93,6 +94,9 @@ public class ModelManager implements Model {
     }
 
     private FilteredList<Card> getActiveFilteredCards() {
+        return new FilteredList<>(filteredCardsList.get(activeCardFolderIndex));
+    }
+    private ObservableList<Card> getActiveObservableCards() {
         return filteredCardsList.get(activeCardFolderIndex);
     }
 
@@ -274,11 +278,18 @@ public class ModelManager implements Model {
         return getActiveFilteredCards();
     }
 
+
     @Override
     public void updateFilteredCard(Predicate<Card> predicate) {
         requireNonNull(predicate);
         FilteredList<Card> filteredCards = getActiveFilteredCards();
         filteredCards.setPredicate(predicate);
+    }
+    @Override
+    public void sortFilteredCard(Comparator<Card> cardComparator) {
+        requireNonNull(cardComparator);
+        FilteredList<Card> filteredCards = getActiveFilteredCards();
+        Collections.sort(filteredCards.getSource(), cardComparator);
     }
 
     //=========== Undo/Redo =================================================================================

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -65,7 +65,7 @@ public class ModelManager implements Model {
 
         filteredCardsList = new ArrayList<>();
         for (int i = 0; i < filteredFoldersList.size(); i++) {
-            ObservableList<Card> filteredCards = new FilteredList<>(filteredFoldersList.get(i).getCardList());
+            FilteredList<Card> filteredCards = new FilteredList<>(filteredFoldersList.get(i).getCardList());
             filteredCardsList.add(filteredCards);
             filteredCards.addListener(this::ensureSelectedCardIsValid);
         }
@@ -288,8 +288,7 @@ public class ModelManager implements Model {
     @Override
     public void sortFilteredCard(Comparator<Card> cardComparator) {
         requireNonNull(cardComparator);
-        FilteredList<Card> filteredCards = getActiveFilteredCards();
-        Collections.sort(filteredCards.getSource(), cardComparator);
+        foldersList.get(activeCardFolderIndex).sortCards(cardComparator);
     }
 
     //=========== Undo/Redo =================================================================================

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -39,7 +39,7 @@ public class ModelManager implements Model {
     private int activeCardFolderIndex;
     private boolean inFolder;
     private final UserPrefs userPrefs;
-    private final List<ObservableList<Card>> filteredCardsList;
+    private final List<FilteredList<Card>> filteredCardsList;
     private final SimpleObjectProperty<Card> selectedCard = new SimpleObjectProperty<>();
     private final SimpleObjectProperty<Card> currentTestedCard = new SimpleObjectProperty<>();
     private boolean insideTestSession = false;
@@ -94,7 +94,7 @@ public class ModelManager implements Model {
     }
 
     private FilteredList<Card> getActiveFilteredCards() {
-        return new FilteredList<>(filteredCardsList.get(activeCardFolderIndex));
+        return filteredCardsList.get(activeCardFolderIndex);
     }
     private ObservableList<Card> getActiveObservableCards() {
         return filteredCardsList.get(activeCardFolderIndex);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -422,7 +422,7 @@ public class ModelManager implements Model {
             }
 
             boolean wasSelectedCardRemoved = change.getRemoved().stream()
-                    .anyMatch(removedCard -> selectedCard.getValue().isSameCard(removedCard));
+                    .anyMatch(removedCard -> selectedCard.getValue().equals(removedCard));
             if (wasSelectedCardRemoved) {
                 // Select the card that came before it in the list,
                 // or clear the selection if there is no such card.

--- a/src/main/java/seedu/address/model/card/Card.java
+++ b/src/main/java/seedu/address/model/card/Card.java
@@ -55,8 +55,7 @@ public class Card {
     }
 
     /**
-     * Returns true if both cards have the same identity and data fields.
-     * This defines a stronger notion of equality between two cards.
+     * Returns true if both cards have the same question and answer.
      */
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/card/Card.java
+++ b/src/main/java/seedu/address/model/card/Card.java
@@ -55,20 +55,6 @@ public class Card {
     }
 
     /**
-     * Returns true if both cards of the same question also have the same answer, but not necessarily the same hint.
-     * This defines a weaker notion of equality between two cards.
-     */
-    public boolean isSameCard(Card otherCard) {
-        if (otherCard == this) {
-            return true;
-        }
-
-        return otherCard != null
-                && otherCard.getQuestion().equals(getQuestion())
-                && (otherCard.getAnswer().equals(getAnswer()));
-    }
-
-    /**
      * Returns true if both cards have the same identity and data fields.
      * This defines a stronger notion of equality between two cards.
      */

--- a/src/main/java/seedu/address/model/card/Card.java
+++ b/src/main/java/seedu/address/model/card/Card.java
@@ -84,9 +84,7 @@ public class Card {
 
         Card otherCard = (Card) other;
         return otherCard.getQuestion().equals(getQuestion())
-                && otherCard.getAnswer().equals(getAnswer())
-                && otherCard.getScore().equals(getScore())
-                && otherCard.getHints().equals(getHints());
+                && otherCard.getAnswer().equals(getAnswer());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/card/Question.java
+++ b/src/main/java/seedu/address/model/card/Question.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Card's question in the card folder.
  * Guarantees: immutable; is valid as declared in {@link #isValidQuestion(String)}
  */
-public class Question {
+public class Question implements Comparable<Question> {
 
     public static final String MESSAGE_CONSTRAINTS = "Questions can take any values, and should not be blank";
     /*
@@ -47,6 +47,11 @@ public class Question {
         return other == this // short circuit if same object
                 || (other instanceof Question // instanceof handles nulls
                 && fullQuestion.equals(((Question) other).fullQuestion)); // state check
+    }
+
+    @Override
+    public int compareTo(Question other) {
+        return fullQuestion.compareTo(other.fullQuestion);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/card/Score.java
+++ b/src/main/java/seedu/address/model/card/Score.java
@@ -119,9 +119,11 @@ public class Score implements Comparable<Score> {
                 && correctAttempts == (((Score) other).correctAttempts)
                 && totalAttempts == (((Score) other).totalAttempts));
     }
+
     @Override
     public int compareTo(Score other) {
-        return (int)(this.getAsDouble() - other.getAsDouble());
+        // Get percentage difference and multiply by 100 to compare as int
+        return (int)(100*(this.getAsDouble() - other.getAsDouble()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/card/Score.java
+++ b/src/main/java/seedu/address/model/card/Score.java
@@ -123,7 +123,7 @@ public class Score implements Comparable<Score> {
     @Override
     public int compareTo(Score other) {
         // Get percentage difference and multiply by 100 to compare as int
-        return (int)(100*(this.getAsDouble() - other.getAsDouble()));
+        return (int) (100 * (this.getAsDouble() - other.getAsDouble()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/card/Score.java
+++ b/src/main/java/seedu/address/model/card/Score.java
@@ -9,7 +9,7 @@ import java.util.Objects;
  * Represents a Card's score in the card folder.
  * Guarantees: immutable; is valid as declared in {@link #isValidScore(String)}
  */
-public class Score {
+public class Score implements Comparable<Score> {
 
     public static final String MESSAGE_CONSTRAINTS = "Score can take a float between 0 and 1 or a string a/b,"
             + "where 0 <= a <= b and a and b are integers.";
@@ -118,6 +118,10 @@ public class Score {
                 || (other instanceof Score // instanceof handles nulls
                 && correctAttempts == (((Score) other).correctAttempts)
                 && totalAttempts == (((Score) other).totalAttempts));
+    }
+    @Override
+    public int compareTo(Score other) {
+        return (int)(this.getAsDouble() - other.getAsDouble());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/card/UniqueCardList.java
+++ b/src/main/java/seedu/address/model/card/UniqueCardList.java
@@ -3,6 +3,8 @@ package seedu.address.model.card;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -82,6 +84,11 @@ public class UniqueCardList implements Iterable<Card> {
     public void setCards(UniqueCardList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);
+    }
+
+    public void sortCards(Comparator<Card> comparator) {
+        requireNonNull(comparator);
+        FXCollections.sort(internalList, comparator);
     }
 
     /**

--- a/src/main/java/seedu/address/model/card/UniqueCardList.java
+++ b/src/main/java/seedu/address/model/card/UniqueCardList.java
@@ -16,8 +16,7 @@ import seedu.address.model.card.exceptions.DuplicateCardException;
  * A list of cards that enforces uniqueness between its elements and does not allow nulls.
  * A card is considered unique by comparing using {@code Card#equals(Card)}. As such, adding and updating of
  * cards uses Card#equals(Card) for equality so as to ensure that the card being added or updated is
- * unique in terms of identity in the UniqueCardList. However, the removal of a card uses Card#equals(Object) so
- * as to ensure that the card with exactly the same fields will be removed.
+ * unique in terms of identity in the UniqueCardList.
  *
  * Supports a minimal set of list operations.
  *

--- a/src/main/java/seedu/address/model/card/UniqueCardList.java
+++ b/src/main/java/seedu/address/model/card/UniqueCardList.java
@@ -14,14 +14,14 @@ import seedu.address.model.card.exceptions.DuplicateCardException;
 
 /**
  * A list of cards that enforces uniqueness between its elements and does not allow nulls.
- * A card is considered unique by comparing using {@code Card#isSameCard(Card)}. As such, adding and updating of
- * cards uses Card#isSameCard(Card) for equality so as to ensure that the card being added or updated is
+ * A card is considered unique by comparing using {@code Card#equals(Card)}. As such, adding and updating of
+ * cards uses Card#equals(Card) for equality so as to ensure that the card being added or updated is
  * unique in terms of identity in the UniqueCardList. However, the removal of a card uses Card#equals(Object) so
  * as to ensure that the card with exactly the same fields will be removed.
  *
  * Supports a minimal set of list operations.
  *
- * @see Card#isSameCard(Card)
+ * @see Card#equals(Card)
  */
 public class UniqueCardList implements Iterable<Card> {
 
@@ -34,7 +34,7 @@ public class UniqueCardList implements Iterable<Card> {
      */
     public boolean contains(Card toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::isSameCard);
+        return internalList.stream().anyMatch(toCheck::equals);
     }
 
     /**
@@ -62,7 +62,7 @@ public class UniqueCardList implements Iterable<Card> {
             throw new CardNotFoundException();
         }
 
-        if (!target.isSameCard(editedCard) && contains(editedCard)) {
+        if (!target.equals(editedCard) && contains(editedCard)) {
             throw new DuplicateCardException();
         }
 
@@ -137,7 +137,7 @@ public class UniqueCardList implements Iterable<Card> {
     private boolean cardsAreUnique(List<Card> cards) {
         for (int i = 0; i < cards.size() - 1; i++) {
             for (int j = i + 1; j < cards.size(); j++) {
-                if (cards.get(i).isSameCard(cards.get(j))) {
+                if (cards.get(i).equals(cards.get(j))) {
                     return false;
                 }
             }

--- a/src/main/java/seedu/address/model/card/UniqueCardList.java
+++ b/src/main/java/seedu/address/model/card/UniqueCardList.java
@@ -3,7 +3,6 @@ package seedu.address.model.card;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -86,11 +85,6 @@ public class UniqueCardList implements Iterable<Card> {
         internalList.setAll(replacement.internalList);
     }
 
-    public void sortCards(Comparator<Card> comparator) {
-        requireNonNull(comparator);
-        FXCollections.sort(internalList, comparator);
-    }
-
     /**
      * Replaces the contents of this list with {@code cards}.
      * {@code cards} must not contain duplicate cards.
@@ -102,6 +96,15 @@ public class UniqueCardList implements Iterable<Card> {
         }
 
         internalList.setAll(cards);
+    }
+
+    /**
+     * Sorts the list using {@code comparator}
+     * @param comparator Comparator to sort cards with.
+     */
+    public void sortCards(Comparator<Card> comparator) {
+        requireNonNull(comparator);
+        FXCollections.sort(internalList, comparator);
     }
 
     /**

--- a/src/test/data/JsonSerializableCardFolderTest/typicalCardsCardFolder.json
+++ b/src/test/data/JsonSerializableCardFolderTest/typicalCardsCardFolder.json
@@ -29,12 +29,12 @@
   }, {
     "question" : "Fiona Kunz",
     "answer" : "9482427",
-    "score" : "0/0",
+    "score" : "1/2",
     "hint" : [ ]
   }, {
     "question" : "George Best",
     "answer" : "9482442",
-    "score" : "0/0",
+    "score" : "2/3",
     "hint" : [ ]
   } ]
 }

--- a/src/test/data/JsonSerializableCardFolderTest/typicalCardsCardFolder.json
+++ b/src/test/data/JsonSerializableCardFolderTest/typicalCardsCardFolder.json
@@ -29,12 +29,12 @@
   }, {
     "question" : "Fiona Kunz",
     "answer" : "9482427",
-    "score" : "1/2",
+    "score" : "2/3",
     "hint" : [ ]
   }, {
     "question" : "George Best",
     "answer" : "9482442",
-    "score" : "2/3",
+    "score" : "1/2",
     "hint" : [ ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -314,7 +314,7 @@ public class AddCommandTest {
         @Override
         public boolean hasCard(Card card) {
             requireNonNull(card);
-            return this.card.isSameCard(card);
+            return this.card.equals(card);
         }
     }
 
@@ -327,7 +327,7 @@ public class AddCommandTest {
         @Override
         public boolean hasCard(Card card) {
             requireNonNull(card);
-            return cardsAdded.stream().anyMatch(card::isSameCard);
+            return cardsAdded.stream().anyMatch(card::equals);
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -240,6 +241,11 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredCard(Predicate<Card> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortFilteredCard(Comparator<Card> comparator) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -38,4 +38,11 @@ public class ListCommandTest {
         showCardAtIndex(model, INDEX_FIRST_CARD);
         assertCommandSuccess(new ListCommand(), model, commandHistory, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
+
+    @Test
+    public void execute_listInCorrectOrder() {
+        model.sortFilteredCard(Model.COMPARATOR_ASC_SCORE_CARDS); // sort in some arbitrary order
+        // List command should re-sort in lexicographic order before listing
+        assertCommandSuccess(new ListCommand(), model, commandHistory, ListCommand.MESSAGE_SUCCESS, expectedModel);
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.answerFirstCard;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showCardAtIndex;
+import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CARD;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
+ */
+public class SortCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Before
+    public void setUp() {
+        model = new ModelManager(getTypicalCardFolders(), new UserPrefs());
+        expectedModel = new ModelManager(model.getCardFolders(), new UserPrefs());
+        expectedModel.sortFilteredCard(Model.COMPARATOR_ASC_SCORE_CARDS);
+    }
+
+    @Test
+    public void execute_sort() {
+        assertCommandSuccess(new SortCommand(), model, commandHistory, SortCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -1,10 +1,7 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.commands.CommandTestUtil.answerFirstCard;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showCardAtIndex;
 import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CARD;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -4,10 +4,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ANSWER_BOB;
+import static seedu.address.model.Model.COMPARATOR_ASC_SCORE_CARDS;
+import static seedu.address.model.Model.COMPARATOR_LEXICOGRAPHIC_CARDS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CARDS;
 import static seedu.address.testutil.TypicalCards.ALICE;
 import static seedu.address.testutil.TypicalCards.BENSON;
 import static seedu.address.testutil.TypicalCards.BOB;
+import static seedu.address.testutil.TypicalCards.FIONA;
+import static seedu.address.testutil.TypicalCards.GEORGE;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -129,6 +133,26 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void sortCards_byScore() {
+        modelManager.addCard(FIONA);
+        modelManager.addCard(GEORGE);
+        modelManager.sortFilteredCard(COMPARATOR_ASC_SCORE_CARDS);
+        // Fiona should be sorted after George because higher score
+        Card lastCard = modelManager.getFilteredCards().get(modelManager.getFilteredCards().size() - 1);
+        assertEquals(FIONA, lastCard);
+    }
+
+    @Test
+    public void sortCards_byQuestionLexicographic() {
+        modelManager.addCard(FIONA);
+        modelManager.addCard(GEORGE);
+        modelManager.sortFilteredCard(COMPARATOR_LEXICOGRAPHIC_CARDS);
+        // Fiona should be sorted after George because higher score
+        Card lastCard = modelManager.getFilteredCards().get(modelManager.getFilteredCards().size() - 1);
+        assertEquals(GEORGE, lastCard);
+    }
+
+    @Test
     public void getFilteredCardList_modifyList_throwsUnsupportedOperationException() {
         thrown.expect(UnsupportedOperationException.class);
         modelManager.getFilteredCards().remove(0);
@@ -183,5 +207,10 @@ public class ModelManagerTest {
         UserPrefs differentUserPrefs = new UserPrefs();
         differentUserPrefs.setcardFolderFilesPath(Paths.get("differentFilePath"));
         assertFalse(modelManager.equals(new ModelManager(Collections.singletonList(cardFolder), differentUserPrefs)));
+
+        // filteredList sorted differently -> returns true
+        modelManager.sortFilteredCard(COMPARATOR_ASC_SCORE_CARDS);
+        assertTrue(modelManager.equals(new ModelManager(Collections.singletonList(cardFolder), userPrefs)));
+
     }
 }

--- a/src/test/java/seedu/address/model/card/CardTest.java
+++ b/src/test/java/seedu/address/model/card/CardTest.java
@@ -80,8 +80,5 @@ public class CardTest {
         editedAlice = new CardBuilder(ALICE).withAnswer(VALID_ANSWER_2).build();
         assertFalse(ALICE.equals(editedAlice));
 
-        // different hint -> returns false
-        editedAlice = new CardBuilder(ALICE).withHint(VALID_HINT_HUSBAND).build();
-        assertFalse(ALICE.equals(editedAlice));
     }
 }

--- a/src/test/java/seedu/address/model/card/CardTest.java
+++ b/src/test/java/seedu/address/model/card/CardTest.java
@@ -28,30 +28,30 @@ public class CardTest {
     @Test
     public void isSameCard() {
         // same object -> returns true
-        assertTrue(ALICE.isSameCard(ALICE));
+        assertTrue(ALICE.equals(ALICE));
 
         // null -> returns false
-        assertFalse(ALICE.isSameCard(null));
+        assertFalse(ALICE.equals(null));
 
         // different answer -> returns false
         Card editedAlice = new CardBuilder(ALICE).withAnswer(VALID_ANSWER_2).build();
-        assertFalse(ALICE.isSameCard(editedAlice));
+        assertFalse(ALICE.equals(editedAlice));
 
         // different question -> returns false
         editedAlice = new CardBuilder(ALICE).withQuestion(VALID_QUESTION_2).build();
-        assertFalse(ALICE.isSameCard(editedAlice));
+        assertFalse(ALICE.equals(editedAlice));
 
         // same question, same answer, different attributes -> returns true
         editedAlice = new CardBuilder(ALICE).withHint(VALID_HINT_HUSBAND).build();
-        assertTrue(ALICE.isSameCard(editedAlice));
+        assertTrue(ALICE.equals(editedAlice));
 
         // same question, different answer, different attributes -> returns false
         editedAlice = new CardBuilder(ALICE).withAnswer(VALID_ANSWER_2).withHint(VALID_HINT_HUSBAND).build();
-        assertFalse(ALICE.isSameCard(editedAlice));
+        assertFalse(ALICE.equals(editedAlice));
 
         // same question, same answer, different attributes -> returns true
         editedAlice = new CardBuilder(ALICE).withHint(VALID_HINT_HUSBAND).build();
-        assertTrue(ALICE.isSameCard(editedAlice));
+        assertTrue(ALICE.equals(editedAlice));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalCards.java
+++ b/src/test/java/seedu/address/testutil/TypicalCards.java
@@ -32,10 +32,10 @@ public class TypicalCards {
             .withScore("0/0").withHint("friends").build();
     public static final Card ELLE = new CardBuilder().withQuestion("Elle Meyer").withAnswer("9482224").withScore("0/0")
             .build();
-    public static final Card FIONA = new CardBuilder().withQuestion("Fiona Kunz").withAnswer("9482427").withScore("1/2")
+    public static final Card FIONA = new CardBuilder().withQuestion("Fiona Kunz").withAnswer("9482427").withScore("2/3")
             .build();
     public static final Card GEORGE = new CardBuilder().withQuestion("George Best").withAnswer("9482442")
-            .withScore("2/3").build();
+            .withScore("1/2").build();
 
     // Manually added
     public static final Card HOON = new CardBuilder().withQuestion("Hoon Meier").withAnswer("8482424").withScore("0/0")

--- a/src/test/java/seedu/address/testutil/TypicalCards.java
+++ b/src/test/java/seedu/address/testutil/TypicalCards.java
@@ -32,10 +32,10 @@ public class TypicalCards {
             .withScore("0/0").withHint("friends").build();
     public static final Card ELLE = new CardBuilder().withQuestion("Elle Meyer").withAnswer("9482224").withScore("0/0")
             .build();
-    public static final Card FIONA = new CardBuilder().withQuestion("Fiona Kunz").withAnswer("9482427").withScore("0/0")
+    public static final Card FIONA = new CardBuilder().withQuestion("Fiona Kunz").withAnswer("9482427").withScore("1/2")
             .build();
     public static final Card GEORGE = new CardBuilder().withQuestion("George Best").withAnswer("9482442")
-            .withScore("0/0").build();
+            .withScore("2/3").build();
 
     // Manually added
     public static final Card HOON = new CardBuilder().withQuestion("Hoon Meier").withAnswer("8482424").withScore("0/0")


### PR DESCRIPTION
Add `sort` command

Sort comand will sort the active filtered cards by percentage score, in ascending order. The sort method is also implemented for ModelManager so that the active filtered cards can be sorted with any provided comparator.

Since we need a way to go back to the "default" ordering (questions in lexicographic order), I also modified the `list` command to first do a sort before listing. So a `list` is now really a `sort` in lexicographic order plus a `list`.

For user story #35 

Ready for review