### PR TITLE
Fix comparator

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -144,7 +144,6 @@ Format: `list`
 
 ====
 * This command is implicitly invoked upon entering a folder, and can be used to reset the view after search or sort.
-* The default ordering is by questions alphabetically.
 ====
 
 ==== Exit folder : `change ..`

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -76,7 +76,7 @@ public class EditCommand extends Command {
         Card cardToEdit = lastShownList.get(index.getZeroBased());
         Card editedCard = createEditedCard(cardToEdit, editCardDescriptor);
 
-        if (!cardToEdit.equals(editedCard) && model.hasCard(editedCard)) {
+        if (!cardToEdit.isSameCard(editedCard) && model.hasCard(editedCard)) {
             throw new CommandException(MESSAGE_DUPLICATE_CARD);
         }
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.COMPARATOR_LEXICOGRAPHIC_CARDS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CARDS;
 
 import seedu.address.logic.CommandHistory;

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -20,7 +20,7 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        model.sortFilteredCard(COMPARATOR_LEXICOGRAPHIC_CARDS);
+        //model.sortFilteredCard(COMPARATOR_LEXICOGRAPHIC_CARDS);
         model.updateFilteredCard(PREDICATE_SHOW_ALL_CARDS);
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -20,7 +20,6 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        //model.sortFilteredCard(COMPARATOR_LEXICOGRAPHIC_CARDS);
         model.updateFilteredCard(PREDICATE_SHOW_ALL_CARDS);
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/model/CardFolder.java
+++ b/src/main/java/seedu/address/model/CardFolder.java
@@ -13,7 +13,7 @@ import seedu.address.model.card.UniqueCardList;
 
 /**
  * Wraps all data at the address-book level
- * Duplicates are not allowed (by .equals comparison)
+ * Duplicates are not allowed (by .isSameCard comparison)
  */
 public class CardFolder implements ReadOnlyCardFolder {
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -405,7 +405,7 @@ public class ModelManager implements Model {
             }
 
             boolean wasSelectedCardRemoved = change.getRemoved().stream()
-                    .anyMatch(removedCard -> selectedCard.getValue().equals(removedCard));
+                    .anyMatch(removedCard -> selectedCard.getValue().isSameCard(removedCard));
             if (wasSelectedCardRemoved) {
                 // Select the card that came before it in the list,
                 // or clear the selection if there is no such card.

--- a/src/main/java/seedu/address/model/card/Card.java
+++ b/src/main/java/seedu/address/model/card/Card.java
@@ -55,7 +55,22 @@ public class Card {
     }
 
     /**
-     * Returns true if both cards have the same question and answer.
+     * Returns true if both cards of the same question also have the same answer, but not necessarily the same hint.
+     * This defines a weaker notion of equality between two cards.
+     */
+    public boolean isSameCard(Card otherCard) {
+        if (otherCard == this) {
+            return true;
+        }
+
+        return otherCard != null
+                && otherCard.getQuestion().equals(getQuestion())
+                && (otherCard.getAnswer().equals(getAnswer()));
+    }
+
+    /**
+     * Returns true if both cards have the same identity and data fields.
+     * This defines a stronger notion of equality between two cards.
      */
     @Override
     public boolean equals(Object other) {
@@ -69,7 +84,9 @@ public class Card {
 
         Card otherCard = (Card) other;
         return otherCard.getQuestion().equals(getQuestion())
-                && otherCard.getAnswer().equals(getAnswer());
+                && otherCard.getAnswer().equals(getAnswer())
+                && otherCard.getScore().equals(getScore())
+                && otherCard.getHints().equals(getHints());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/card/UniqueCardList.java
+++ b/src/main/java/seedu/address/model/card/UniqueCardList.java
@@ -14,13 +14,20 @@ import seedu.address.model.card.exceptions.DuplicateCardException;
 
 /**
  * A list of cards that enforces uniqueness between its elements and does not allow nulls.
+<<<<<<< HEAD
  * A card is considered unique by comparing using {@code Card#equals(Card)}. As such, adding and updating of
  * cards uses Card#equals(Card) for equality so as to ensure that the card being added or updated is
  * unique in terms of identity in the UniqueCardList.
+=======
+ * A card is considered unique by comparing using {@code Card#isSameCard(Card)}. As such, adding and updating of
+ * cards uses Card#isSameCard(Card) for equality so as to ensure that the card being added or updated is
+ * unique in terms of identity in the UniqueCardList. However, the removal of a card uses Card#equals(Object) so
+ * as to ensure that the card with exactly the same fields will be removed.
+>>>>>>> parent of 76f8cb02... replace all isSameCard with equal
  *
  * Supports a minimal set of list operations.
  *
- * @see Card#equals(Card)
+ * @see Card#isSameCard(Card)
  */
 public class UniqueCardList implements Iterable<Card> {
 
@@ -33,7 +40,7 @@ public class UniqueCardList implements Iterable<Card> {
      */
     public boolean contains(Card toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::equals);
+        return internalList.stream().anyMatch(toCheck::isSameCard);
     }
 
     /**
@@ -61,7 +68,7 @@ public class UniqueCardList implements Iterable<Card> {
             throw new CardNotFoundException();
         }
 
-        if (!target.equals(editedCard) && contains(editedCard)) {
+        if (!target.isSameCard(editedCard) && contains(editedCard)) {
             throw new DuplicateCardException();
         }
 
@@ -136,7 +143,7 @@ public class UniqueCardList implements Iterable<Card> {
     private boolean cardsAreUnique(List<Card> cards) {
         for (int i = 0; i < cards.size() - 1; i++) {
             for (int j = i + 1; j < cards.size(); j++) {
-                if (cards.get(i).equals(cards.get(j))) {
+                if (cards.get(i).isSameCard(cards.get(j))) {
                     return false;
                 }
             }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -336,7 +336,7 @@ public class AddCommandTest {
         @Override
         public boolean hasCard(Card card) {
             requireNonNull(card);
-            return this.card.equals(card);
+            return this.card.isSameCard(card);
         }
 
         @Override
@@ -354,7 +354,7 @@ public class AddCommandTest {
         @Override
         public boolean hasCard(Card card) {
             requireNonNull(card);
-            return cardsAdded.stream().anyMatch(card::equals);
+            return cardsAdded.stream().anyMatch(card::isSameCard);
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -38,11 +38,4 @@ public class ListCommandTest {
         showCardAtIndex(model, INDEX_FIRST_CARD);
         assertCommandSuccess(new ListCommand(), model, commandHistory, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
-
-    @Test
-    public void execute_listInCorrectOrder() {
-        model.sortFilteredCard(Model.COMPARATOR_ASC_SCORE_CARDS); // sort in some arbitrary order
-        // List command should re-sort in lexicographic order before listing
-        assertCommandSuccess(new ListCommand(), model, commandHistory, ListCommand.MESSAGE_SUCCESS, expectedModel);
-    }
 }

--- a/src/test/java/seedu/address/model/card/CardTest.java
+++ b/src/test/java/seedu/address/model/card/CardTest.java
@@ -28,30 +28,30 @@ public class CardTest {
     @Test
     public void isSameCard() {
         // same object -> returns true
-        assertTrue(ALICE.equals(ALICE));
+        assertTrue(ALICE.isSameCard(ALICE));
 
         // null -> returns false
-        assertFalse(ALICE.equals(null));
+        assertFalse(ALICE.isSameCard(null));
 
         // different answer -> returns false
         Card editedAlice = new CardBuilder(ALICE).withAnswer(VALID_ANSWER_2).build();
-        assertFalse(ALICE.equals(editedAlice));
+        assertFalse(ALICE.isSameCard(editedAlice));
 
         // different question -> returns false
         editedAlice = new CardBuilder(ALICE).withQuestion(VALID_QUESTION_2).build();
-        assertFalse(ALICE.equals(editedAlice));
+        assertFalse(ALICE.isSameCard(editedAlice));
 
         // same question, same answer, different attributes -> returns true
         editedAlice = new CardBuilder(ALICE).withHint(VALID_HINT_HUSBAND).build();
-        assertTrue(ALICE.equals(editedAlice));
+        assertTrue(ALICE.isSameCard(editedAlice));
 
         // same question, different answer, different attributes -> returns false
         editedAlice = new CardBuilder(ALICE).withAnswer(VALID_ANSWER_2).withHint(VALID_HINT_HUSBAND).build();
-        assertFalse(ALICE.equals(editedAlice));
+        assertFalse(ALICE.isSameCard(editedAlice));
 
         // same question, same answer, different attributes -> returns true
         editedAlice = new CardBuilder(ALICE).withHint(VALID_HINT_HUSBAND).build();
-        assertTrue(ALICE.equals(editedAlice));
+        assertTrue(ALICE.isSameCard(editedAlice));
     }
 
     @Test

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -168,9 +168,7 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
                 + INVALID_HINT_DESC, Hint.MESSAGE_CONSTRAINTS);
 
         /* Case: edit a card with new values same as another card's values -> rejected */
-        //executeCommand(CardUtil.getAddCommand(CARD_2));
-        executeCommand("add q/Sample Question 2 a/Sample Answer 2 h/husband");
-        // EDIT
+        executeCommand(CardUtil.getAddCommand(CARD_2));
         assertTrue(getModel().getActiveCardFolder().getCardList().contains(CARD_2));
         index = INDEX_FIRST_CARD;
         assertFalse(getModel().getFilteredCards().get(index.getZeroBased()).equals(CARD_2));

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -168,7 +168,9 @@ public class EditCommandSystemTest extends CardFolderSystemTest {
                 + INVALID_HINT_DESC, Hint.MESSAGE_CONSTRAINTS);
 
         /* Case: edit a card with new values same as another card's values -> rejected */
-        executeCommand(CardUtil.getAddCommand(CARD_2));
+        //executeCommand(CardUtil.getAddCommand(CARD_2));
+        executeCommand("add q/Sample Question 2 a/Sample Answer 2 h/husband");
+        // EDIT
         assertTrue(getModel().getActiveCardFolder().getCardList().contains(CARD_2));
         index = INDEX_FIRST_CARD;
         assertFalse(getModel().getFilteredCards().get(index.getZeroBased()).equals(CARD_2));


### PR DESCRIPTION
Revert "replace all isSameCard with equal" 

This PR fixes a bug introduced by my previous PR #75 which makes the `list` command sort alphabetically. This caused some system tests to fail mysteriously as they worked based on position of cards e.g. CARD_1 is expected to be at index 0, and the `list` caused the card to move somewhere else. 

To fix that, in #75 I had combined weak equality (isSameCard) and strong equality (equals) into weak equality only. This caused more bugs downstream as the `edit` command now could not detect when a card's hint field changed because hints are not checked in weak equality.

The notion of weak and strong equality is needed because we need to be able to check when a user is adding a card with duplicate identity fields, as well as tell when data fields of a particular card have changed.

So this PR removes the alphabetical sort of `list`, and brings back weak and strong equality.

Ready for review