### PR TITLE
Refactor CommandResult

### DIFF
--- a/src/main/java/seedu/address/logic/AnswerCommandResultType.java
+++ b/src/main/java/seedu/address/logic/AnswerCommandResultType.java
@@ -1,8 +1,0 @@
-package seedu.address.logic;
-
-/**
- * Define the different types that the result of a AnswerCommand can take on.
- */
-public enum AnswerCommandResultType {
-    NOT_ANSWER_COMMAND, ANSWER_CORRECT, ANSWER_WRONG
-}

--- a/src/main/java/seedu/address/logic/commands/AnswerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnswerCommand.java
@@ -54,11 +54,9 @@ public class AnswerCommand extends Command {
         model.updateFilteredCard(PREDICATE_SHOW_ALL_CARDS);
         model.commitActiveCardFolder();
         if (isAttemptCorrect) {
-            return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, false, false, null,
-                    false, AnswerCommandResultType.ANSWER_CORRECT);
+            return new CommandResult(MESSAGE_ANSWER_SUCCESS, CommandResult.TYPE.ANSWER_CORRECT);
         } else {
-            return new CommandResult(MESSAGE_ANSWER_SUCCESS, false, false, false, false, null,
-                    false, AnswerCommandResultType.ANSWER_WRONG);
+            return new CommandResult(MESSAGE_ANSWER_SUCCESS, CommandResult.TYPE.ANSWER_WRONG);
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/AnswerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AnswerCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CARDS;
 
 import seedu.address.commons.core.Messages;
-import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -54,9 +53,9 @@ public class AnswerCommand extends Command {
         model.updateFilteredCard(PREDICATE_SHOW_ALL_CARDS);
         model.commitActiveCardFolder();
         if (isAttemptCorrect) {
-            return new CommandResult(MESSAGE_ANSWER_SUCCESS, CommandResult.TYPE.ANSWER_CORRECT);
+            return new CommandResult(MESSAGE_ANSWER_SUCCESS, CommandResult.Type.ANSWER_CORRECT);
         } else {
-            return new CommandResult(MESSAGE_ANSWER_SUCCESS, CommandResult.TYPE.ANSWER_WRONG);
+            return new CommandResult(MESSAGE_ANSWER_SUCCESS, CommandResult.Type.ANSWER_WRONG);
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/ChangeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ChangeCommand.java
@@ -52,8 +52,7 @@ public class ChangeCommand extends Command {
                 throw new CommandException(Messages.MESSAGE_ILLEGAL_COMMAND_NOT_IN_FOLDER);
             }
             model.exitFoldersToHome();
-            return new CommandResult(MESSAGE_EXIT_FOLDER_SUCCESS,
-                    false, false, false, true, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
+            return new CommandResult(MESSAGE_EXIT_FOLDER_SUCCESS, CommandResult.TYPE.EXITED_FOLDER);
         } else {
             if (model.isInFolder()) {
                 throw new CommandException(Messages.MESSAGE_ILLEGAL_COMMAND_NOT_IN_HOME);
@@ -64,7 +63,7 @@ public class ChangeCommand extends Command {
             }
             model.setActiveCardFolderIndex(targetIndex.getZeroBased());
             return new CommandResult(String.format(MESSAGE_ENTER_FOLDER_SUCCESS, targetIndex.getOneBased()),
-                    false, false, true, false, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
+                    CommandResult.TYPE.ENTERED_FOLDER);
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/ChangeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ChangeCommand.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -52,7 +51,7 @@ public class ChangeCommand extends Command {
                 throw new CommandException(Messages.MESSAGE_ILLEGAL_COMMAND_NOT_IN_FOLDER);
             }
             model.exitFoldersToHome();
-            return new CommandResult(MESSAGE_EXIT_FOLDER_SUCCESS, CommandResult.TYPE.EXITED_FOLDER);
+            return new CommandResult(MESSAGE_EXIT_FOLDER_SUCCESS, CommandResult.Type.EXITED_FOLDER);
         } else {
             if (model.isInFolder()) {
                 throw new CommandException(Messages.MESSAGE_ILLEGAL_COMMAND_NOT_IN_HOME);
@@ -63,7 +62,7 @@ public class ChangeCommand extends Command {
             }
             model.setActiveCardFolderIndex(targetIndex.getZeroBased());
             return new CommandResult(String.format(MESSAGE_ENTER_FOLDER_SUCCESS, targetIndex.getOneBased()),
-                    CommandResult.TYPE.ENTERED_FOLDER);
+                    CommandResult.Type.ENTERED_FOLDER);
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -16,114 +16,48 @@ public class CommandResult {
 
     private final String feedbackToUser;
 
-    /** Help information should be shown to the user. */
-    private final boolean showHelp;
+    public enum TYPE {
+        SHOW_HELP, /** Help information should be shown to the user. */
+        IS_EXIT, /** The application should exit. */
+        ENTERED_FOLDER, /** The side panel should be updated as folder was entered. */
+        EXITED_FOLDER, /** The side panel should be updated as folder was exited. */
+        TEST_SESSION_CARD, /** The application should enter a test session. */
+        END_TEST_SESSION,  /** The current test session should end. */
+        ANSWER_CORRECT,
+        ANSWER_WRONG,
+        NONE // use for "nothing to do"
+    }
 
-    /** The application should exit. */
-    private final boolean exit;
+    private Card testSessionCard;
 
-    /** The side panel should be updated as folder was entered. */
-    private final boolean enteredFolder;
-
-    /** The side panel should be updated as folder was exited. */
-    private final boolean exitedFolder;
-
-    /** The application should enter a test session. */
-    private final Card testSessionCard;
-
-    /** The current test session should end. */
-    private final boolean endTestSession;
-
-    /** The application should show to user whether answer attempted is correct or wrong. */
-    private final AnswerCommandResultType answerCommandResult;
+    public TYPE type;
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit,
-                         boolean enteredFolder, boolean exitedFolder,
-                         Card testSessionCard, boolean endTestSession, AnswerCommandResultType answerCommandResult) {
+    public CommandResult(String feedbackToUser, TYPE type) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
-        this.showHelp = showHelp;
-        this.exit = exit;
-        this.enteredFolder = enteredFolder;
-        this.exitedFolder = exitedFolder;
-        this.testSessionCard = testSessionCard;
-        this.endTestSession = endTestSession;
-        this.answerCommandResult = answerCommandResult;
+        this.type = type;
     }
 
-    /**
-     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
-     * and other fields set to their default value.
-     */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false, false, false, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
+        this(feedbackToUser, TYPE.NONE);
     }
 
     public String getFeedbackToUser() {
         return feedbackToUser;
     }
 
-    public boolean isShowHelp() {
-        return showHelp;
-    }
-
-    public boolean isExit() {
-        return exit;
-    }
-
-    public boolean isEndTestSession() {
-        return endTestSession;
-    }
-
-    /**
-     * Check if command is to enter test session
-     * @return a boolean variable to state if command is test or not
-     */
-    public boolean isTestSession() {
-        if (testSessionCard == null) {
-            return false;
-        }
-        return true;
+    public void setTestSessionCard(Card card) {
+        testSessionCard = card;
     }
 
     public Card getTestSessionCard() {
         return testSessionCard;
     }
 
-    /**
-     * Check if command is an ans command
-     * @return a boolean variable to state if command is ans or not
-     */
-    public boolean isAnswerCommand() {
-        if (answerCommandResult == AnswerCommandResultType.NOT_ANSWER_COMMAND) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * Check if attempted answer is correct or wrong
-     * This method should be called only if a valid ans command is called
-     * @return a boolean variable to state if command is ans or not
-     */
-    public boolean isAnswerCorrect() throws CommandException {
-        if (answerCommandResult == AnswerCommandResultType.ANSWER_CORRECT) {
-            return true;
-        } else if (answerCommandResult == AnswerCommandResultType.ANSWER_WRONG) {
-            return false;
-        } else {
-            throw new CommandException(Messages.MESSAGE_INVALID_ANSWER_COMMAND);
-        }
-    }
-
-    public boolean enteredFolder() throws CommandException {
-        return enteredFolder;
-    }
-
-    public boolean exitedFolder() {
-        return exitedFolder;
+    public TYPE getType() {
+        return this.type;
     }
 
     @Override
@@ -139,16 +73,12 @@ public class CommandResult {
 
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
-                && showHelp == otherCommandResult.showHelp
-                && exit == otherCommandResult.exit
-                && testSessionCard == otherCommandResult.testSessionCard
-                && endTestSession == otherCommandResult.endTestSession
-                && answerCommandResult == otherCommandResult.answerCommandResult;
+                && type == otherCommandResult.getType();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit, testSessionCard, endTestSession, answerCommandResult);
+        return Objects.hash(feedbackToUser, type);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -4,9 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
-import seedu.address.commons.core.Messages;
-import seedu.address.logic.AnswerCommandResultType;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.card.Card;
 
 /**
@@ -16,32 +13,35 @@ public class CommandResult {
 
     private final String feedbackToUser;
 
-    public enum TYPE {
-        SHOW_HELP, /** Help information should be shown to the user. */
-        IS_EXIT, /** The application should exit. */
-        ENTERED_FOLDER, /** The side panel should be updated as folder was entered. */
-        EXITED_FOLDER, /** The side panel should be updated as folder was exited. */
-        TEST_SESSION_CARD, /** The application should enter a test session. */
-        END_TEST_SESSION,  /** The current test session should end. */
+    /**
+     * {@code Type } representing the type of CommandResult and what response should be displayed.
+     */
+    public enum Type {
+        SHOW_HELP, // Help information should be shown to the user.
+        IS_EXIT, // The application should exit.
+        ENTERED_FOLDER, // The side panel should be updated as folder was entered.
+        EXITED_FOLDER, // The side panel should be updated as folder was exited.
+        TEST_SESSION_CARD, // The application should enter a test session.
+        END_TEST_SESSION, // The current test session should end.
         ANSWER_CORRECT,
         ANSWER_WRONG,
         NONE // use for "nothing to do"
     }
 
-    private Card testSessionCard;
+    private Type type;
 
-    public TYPE type;
+    private Card testSessionCard;
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, TYPE type) {
+    public CommandResult(String feedbackToUser, Type type) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.type = type;
     }
 
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, TYPE.NONE);
+        this(feedbackToUser, Type.NONE);
     }
 
     public String getFeedbackToUser() {
@@ -56,7 +56,7 @@ public class CommandResult {
         return testSessionCard;
     }
 
-    public TYPE getType() {
+    public Type getType() {
         return this.type;
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteFolderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteFolderCommand.java
@@ -47,8 +47,7 @@ public class DeleteFolderCommand extends Command {
         ReadOnlyCardFolder cardFolderToDelete = cardFolderList.get(targetIndex.getZeroBased());
 
         model.deleteFolder(targetIndex.getZeroBased());
-        return new CommandResult(String.format(MESSAGE_DELETE_FOLDER_SUCCESS, cardFolderToDelete),
-                false, false, false, false, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
+        return new CommandResult(String.format(MESSAGE_DELETE_FOLDER_SUCCESS, cardFolderToDelete));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteFolderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteFolderCommand.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;

--- a/src/main/java/seedu/address/logic/commands/EndCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EndCommand.java
@@ -22,8 +22,7 @@ public class EndCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_COMMAND_OUTSIDE_TEST_SESSION);
         }
         model.endTestSession();
-        return new CommandResult(MESSAGE_END_TEST_SESSION_SUCCESS, false, false, false, false, null, true,
-                AnswerCommandResultType.NOT_ANSWER_COMMAND);
+        return new CommandResult(MESSAGE_END_TEST_SESSION_SUCCESS, CommandResult.TYPE.END_TEST_SESSION);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/EndCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EndCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import seedu.address.commons.core.Messages;
-import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -22,7 +21,7 @@ public class EndCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_COMMAND_OUTSIDE_TEST_SESSION);
         }
         model.endTestSession();
-        return new CommandResult(MESSAGE_END_TEST_SESSION_SUCCESS, CommandResult.TYPE.END_TEST_SESSION);
+        return new CommandResult(MESSAGE_END_TEST_SESSION_SUCCESS, CommandResult.Type.END_TEST_SESSION);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.commands;
 
-import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 
@@ -15,7 +14,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, CommandResult.TYPE.IS_EXIT);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, CommandResult.Type.IS_EXIT);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -15,8 +15,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false, false, null, false,
-                AnswerCommandResultType.NOT_ANSWER_COMMAND);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, CommandResult.TYPE.IS_EXIT);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -18,7 +18,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false, null, false,
-                AnswerCommandResultType.NOT_ANSWER_COMMAND);
+        return new CommandResult(SHOWING_HELP_MESSAGE, CommandResult.TYPE.SHOW_HELP);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.commands;
 
-import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 
@@ -18,6 +17,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, CommandResult.TYPE.SHOW_HELP);
+        return new CommandResult(SHOWING_HELP_MESSAGE, CommandResult.Type.SHOW_HELP);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/TestCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TestCommand.java
@@ -49,8 +49,10 @@ public class TestCommand extends Command {
         model.setActiveCardFolderIndex(targetIndex.getZeroBased());
         model.testCardFolder(targetIndex.getZeroBased());
         Card cardToTest = model.getCurrentTestedCard();
-        return new CommandResult(MESSAGE_ENTER_TEST_FOLDER_SUCCESS, false, false, false, false, cardToTest, false,
-                AnswerCommandResultType.NOT_ANSWER_COMMAND);
+        CommandResult commandResult = new CommandResult(MESSAGE_ENTER_TEST_FOLDER_SUCCESS,
+                CommandResult.TYPE.TEST_SESSION_CARD);
+        commandResult.setTestSessionCard(cardToTest);
+        return commandResult;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/TestCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TestCommand.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -50,7 +49,7 @@ public class TestCommand extends Command {
         model.testCardFolder(targetIndex.getZeroBased());
         Card cardToTest = model.getCurrentTestedCard();
         CommandResult commandResult = new CommandResult(MESSAGE_ENTER_TEST_FOLDER_SUCCESS,
-                CommandResult.TYPE.TEST_SESSION_CARD);
+                CommandResult.Type.TEST_SESSION_CARD);
         commandResult.setTestSessionCard(cardToTest);
         return commandResult;
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -241,31 +241,31 @@ public class MainWindow extends UiPart<Stage> {
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
             switch (commandResult.getType()) {
-                case SHOW_HELP:
-                    handleHelp();
-                    break;
-                case IS_EXIT:
-                    handleExit();
-                    break;
-                case ENTERED_FOLDER:
-                    handleEnterFolder();
-                    break;
-                case EXITED_FOLDER:
-                    handleExitFolder();
-                    break;
-                case TEST_SESSION_CARD:
-                    handleStartTestSession(commandResult.getTestSessionCard());
-                    break;
-                case END_TEST_SESSION:
-                    handleEndTestSession();
-                    break;
-                case ANSWER_CORRECT:
-                    handleCorrectAnswer();
-                    break;
-                case ANSWER_WRONG:
-                    handleWrongAnswer();
-                    break;
-
+            case SHOW_HELP:
+                handleHelp();
+                break;
+            case IS_EXIT:
+                handleExit();
+                break;
+            case ENTERED_FOLDER:
+                handleEnterFolder();
+                break;
+            case EXITED_FOLDER:
+                handleExitFolder();
+                break;
+            case TEST_SESSION_CARD:
+                handleStartTestSession(commandResult.getTestSessionCard());
+                break;
+            case END_TEST_SESSION:
+                handleEndTestSession();
+                break;
+            case ANSWER_CORRECT:
+                handleCorrectAnswer();
+                break;
+            case ANSWER_WRONG:
+                handleWrongAnswer();
+                break;
+            default:
             }
 
             return commandResult;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -240,36 +240,32 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
-            if (commandResult.isShowHelp()) {
-                handleHelp();
-            }
-
-            if (commandResult.isExit()) {
-                handleExit();
-            }
-
-            if (commandResult.enteredFolder()) {
-                handleEnterFolder();
-            }
-
-            if (commandResult.exitedFolder()) {
-                handleExitFolder();
-            }
-
-            if (commandResult.isTestSession()) {
-                handleStartTestSession(commandResult.getTestSessionCard());
-            }
-
-            if (commandResult.isEndTestSession()) {
-                handleEndTestSession();
-            }
-
-            if (commandResult.isAnswerCommand()) {
-                if (commandResult.isAnswerCorrect()) {
+            switch (commandResult.getType()) {
+                case SHOW_HELP:
+                    handleHelp();
+                    break;
+                case IS_EXIT:
+                    handleExit();
+                    break;
+                case ENTERED_FOLDER:
+                    handleEnterFolder();
+                    break;
+                case EXITED_FOLDER:
+                    handleExitFolder();
+                    break;
+                case TEST_SESSION_CARD:
+                    handleStartTestSession(commandResult.getTestSessionCard());
+                    break;
+                case END_TEST_SESSION:
+                    handleEndTestSession();
+                    break;
+                case ANSWER_CORRECT:
                     handleCorrectAnswer();
-                } else {
+                    break;
+                case ANSWER_WRONG:
                     handleWrongAnswer();
-                }
+                    break;
+
             }
 
             return commandResult;

--- a/src/test/java/seedu/address/logic/commands/AnswerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AnswerCommandTest.java
@@ -57,8 +57,8 @@ public class AnswerCommandTest {
 
     @Test
     public void execute_correctAnswerAttempt_markCorrect() {
-        CommandResult expectedCommandResult = new CommandResult(AnswerCommand.MESSAGE_ANSWER_SUCCESS, false,
-                false, false, false, null, false, AnswerCommandResultType.ANSWER_CORRECT);
+        CommandResult expectedCommandResult = new CommandResult(AnswerCommand.MESSAGE_ANSWER_SUCCESS,
+                CommandResult.TYPE.ANSWER_CORRECT);
 
         model.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
         expectedModel.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
@@ -78,8 +78,8 @@ public class AnswerCommandTest {
 
     @Test
     public void execute_wrongAnswerAttempt_markWrong() {
-        CommandResult expectedCommandResult = new CommandResult(AnswerCommand.MESSAGE_ANSWER_SUCCESS, false,
-                false, false, false, null, false, AnswerCommandResultType.ANSWER_WRONG);
+        CommandResult expectedCommandResult = new CommandResult(AnswerCommand.MESSAGE_ANSWER_SUCCESS,
+                CommandResult.TYPE.ANSWER_WRONG);
 
         model.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
         expectedModel.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/AnswerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AnswerCommandTest.java
@@ -12,7 +12,6 @@ import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
 
 import org.junit.Test;
 
-import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -58,7 +57,7 @@ public class AnswerCommandTest {
     @Test
     public void execute_correctAnswerAttempt_markCorrect() {
         CommandResult expectedCommandResult = new CommandResult(AnswerCommand.MESSAGE_ANSWER_SUCCESS,
-                CommandResult.TYPE.ANSWER_CORRECT);
+                CommandResult.Type.ANSWER_CORRECT);
 
         model.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
         expectedModel.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
@@ -79,7 +78,7 @@ public class AnswerCommandTest {
     @Test
     public void execute_wrongAnswerAttempt_markWrong() {
         CommandResult expectedCommandResult = new CommandResult(AnswerCommand.MESSAGE_ANSWER_SUCCESS,
-                CommandResult.TYPE.ANSWER_WRONG);
+                CommandResult.Type.ANSWER_WRONG);
 
         model.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
         expectedModel.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -60,19 +60,25 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.Type.SHOW_HELP).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback",
+                CommandResult.Type.SHOW_HELP).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.Type.IS_EXIT).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback",
+                CommandResult.Type.IS_EXIT).hashCode());
 
         // different testSessionCard value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.Type.TEST_SESSION_CARD).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback",
+                CommandResult.Type.TEST_SESSION_CARD).hashCode());
 
         // different endTestSession value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.Type.END_TEST_SESSION).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback",
+                CommandResult.Type.END_TEST_SESSION).hashCode());
 
         // different AnswerCommandResult value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.Type.ANSWER_CORRECT).hashCode());
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.Type.ANSWER_WRONG).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback",
+                CommandResult.Type.ANSWER_CORRECT).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback",
+                CommandResult.Type.ANSWER_WRONG).hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.model.card.Card;
 import seedu.address.testutil.CardBuilder;
 
@@ -19,7 +18,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", CommandResult.TYPE.NONE)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", CommandResult.Type.NONE)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -33,20 +32,20 @@ public class CommandResultTest {
         // different feedbackToUser value -> returns false
         assertFalse(commandResult.equals(new CommandResult("different")));
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.TYPE.SHOW_HELP)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.Type.SHOW_HELP)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.TYPE.IS_EXIT)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.Type.IS_EXIT)));
 
         // different testSessionCard value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.TYPE.TEST_SESSION_CARD)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.Type.TEST_SESSION_CARD)));
 
         // different endTestSession value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.TYPE.END_TEST_SESSION)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.Type.END_TEST_SESSION)));
 
         // different AnswerCommandResult value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.TYPE.ANSWER_CORRECT)));
-        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.TYPE.ANSWER_WRONG)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.Type.ANSWER_CORRECT)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.Type.ANSWER_WRONG)));
     }
 
     @Test
@@ -61,19 +60,19 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.TYPE.SHOW_HELP).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.Type.SHOW_HELP).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.TYPE.IS_EXIT).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.Type.IS_EXIT).hashCode());
 
         // different testSessionCard value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.TYPE.TEST_SESSION_CARD).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.Type.TEST_SESSION_CARD).hashCode());
 
         // different endTestSession value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.TYPE.END_TEST_SESSION).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.Type.END_TEST_SESSION).hashCode());
 
         // different AnswerCommandResult value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.TYPE.ANSWER_CORRECT).hashCode());
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.TYPE.ANSWER_WRONG).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.Type.ANSWER_CORRECT).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.Type.ANSWER_WRONG).hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -19,8 +19,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false,
-                false, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", CommandResult.TYPE.NONE)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -34,26 +33,20 @@ public class CommandResultTest {
         // different feedbackToUser value -> returns false
         assertFalse(commandResult.equals(new CommandResult("different")));
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false,
-                false, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.TYPE.SHOW_HELP)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false,
-                false, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.TYPE.IS_EXIT)));
 
         // different testSessionCard value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false,
-                false, sampleTestCard, false, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.TYPE.TEST_SESSION_CARD)));
 
         // different endTestSession value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false,
-                false, null, true, AnswerCommandResultType.NOT_ANSWER_COMMAND)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.TYPE.END_TEST_SESSION)));
 
         // different AnswerCommandResult value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false,
-                false, null, false, AnswerCommandResultType.ANSWER_CORRECT)));
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false,
-                false, null, false, AnswerCommandResultType.ANSWER_WRONG)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.TYPE.ANSWER_CORRECT)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", CommandResult.TYPE.ANSWER_WRONG)));
     }
 
     @Test
@@ -68,25 +61,19 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, false,
-                false, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.TYPE.SHOW_HELP).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false,
-                false, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.TYPE.IS_EXIT).hashCode());
 
         // different testSessionCard value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, false,
-                false, sampleTestCard, false, AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.TYPE.TEST_SESSION_CARD).hashCode());
 
         // different endTestSession value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, false,
-                false, null, true, AnswerCommandResultType.NOT_ANSWER_COMMAND).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.TYPE.END_TEST_SESSION).hashCode());
 
         // different AnswerCommandResult value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, false,
-                false, null, false, AnswerCommandResultType.ANSWER_CORRECT).hashCode());
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, false,
-                false, null, false, AnswerCommandResultType.ANSWER_WRONG).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.TYPE.ANSWER_CORRECT).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", CommandResult.TYPE.ANSWER_WRONG).hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EndCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EndCommandTest.java
@@ -30,8 +30,8 @@ public class EndCommandTest {
 
         expectedModel.endTestSession();
 
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_END_TEST_SESSION_SUCCESS, false, false,
-                false, false, null, true, AnswerCommandResultType.NOT_ANSWER_COMMAND);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_END_TEST_SESSION_SUCCESS,
+                CommandResult.TYPE.END_TEST_SESSION);
         assertCommandSuccess(new EndCommand(), model, commandHistory, expectedCommandResult, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/EndCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EndCommandTest.java
@@ -8,7 +8,6 @@ import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
 
 import org.junit.Test;
 
-import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -31,7 +30,7 @@ public class EndCommandTest {
         expectedModel.endTestSession();
 
         CommandResult expectedCommandResult = new CommandResult(MESSAGE_END_TEST_SESSION_SUCCESS,
-                CommandResult.TYPE.END_TEST_SESSION);
+                CommandResult.Type.END_TEST_SESSION);
         assertCommandSuccess(new EndCommand(), model, commandHistory, expectedCommandResult, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -17,8 +17,8 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false,
-                false, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT,
+                CommandResult.TYPE.IS_EXIT);
         assertCommandSuccess(new ExitCommand(), model, commandHistory, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.commands.ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEM
 
 import org.junit.Test;
 
-import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -18,7 +17,7 @@ public class ExitCommandTest {
     @Test
     public void execute_exit_success() {
         CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT,
-                CommandResult.TYPE.IS_EXIT);
+                CommandResult.Type.IS_EXIT);
         assertCommandSuccess(new ExitCommand(), model, commandHistory, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.commands.HelpCommand.SHOWING_HELP_MESSAGE;
 
 import org.junit.Test;
 
-import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -17,7 +16,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, CommandResult.TYPE.SHOW_HELP);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, CommandResult.Type.SHOW_HELP);
         assertCommandSuccess(new HelpCommand(), model, commandHistory, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -17,8 +17,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, false,
-                false, null, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, CommandResult.TYPE.SHOW_HELP);
         assertCommandSuccess(new HelpCommand(), model, commandHistory, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/TestCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TestCommandTest.java
@@ -32,8 +32,8 @@ public class TestCommandTest {
         expectedModel.testCardFolder(TypicalIndexes.INDEX_FIRST_CARD_FOLDER.getZeroBased());
         Card cardToTest = expectedModel.getCurrentTestedCard();
 
-        CommandResult expectedCommandResult = new CommandResult(TestCommand.MESSAGE_ENTER_TEST_FOLDER_SUCCESS, false,
-                false, false, false, cardToTest, false, AnswerCommandResultType.NOT_ANSWER_COMMAND);
+        CommandResult expectedCommandResult = new CommandResult(TestCommand.MESSAGE_ENTER_TEST_FOLDER_SUCCESS,
+                CommandResult.TYPE.TEST_SESSION_CARD);
         assertCommandSuccess(testCommand, model, commandHistory, expectedCommandResult, expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/TestCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TestCommandTest.java
@@ -9,7 +9,6 @@ import static seedu.address.testutil.TypicalCards.getTypicalCardFolders;
 
 import org.junit.Test;
 
-import seedu.address.logic.AnswerCommandResultType;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -33,7 +32,7 @@ public class TestCommandTest {
         Card cardToTest = expectedModel.getCurrentTestedCard();
 
         CommandResult expectedCommandResult = new CommandResult(TestCommand.MESSAGE_ENTER_TEST_FOLDER_SUCCESS,
-                CommandResult.TYPE.TEST_SESSION_CARD);
+                CommandResult.Type.TEST_SESSION_CARD);
         assertCommandSuccess(testCommand, model, commandHistory, expectedCommandResult, expectedModel);
     }
 


### PR DESCRIPTION
big ass refactor for `CommandResult`

Instead of checking a bunch of booleans,  `CommandResult` is now checked by a switch + enums. Because only one of the many booleans will be true at any point in time anyways. This makes it much easier to add or change the type of `CommandResults` that can be returned.

To add more `CommandResult`s, simply add to the enum list and check for the enum in `MainWindow`.

You're welcome.